### PR TITLE
Fix error range

### DIFF
--- a/src/proto3Diagnostic.ts
+++ b/src/proto3Diagnostic.ts
@@ -8,37 +8,53 @@ export class Proto3LanguageDiagnosticProvider {
 
     private errors = vscode.languages.createDiagnosticCollection("languageErrors");
 
-    public createDiagnostics(docUri: vscode.Uri, fileName: string) {
-        new Proto3Compiler().compileProtoToTmp(fileName, stderr => {
-            //console.log(stderr);
+    public createDiagnostics(doc: vscode.TextDocument) {
+        new Proto3Compiler().compileProtoToTmp(doc.fileName, stderr => {
             if (stderr) {
-                this.analyzeErrors(docUri, fileName, stderr);
+                this.analyzeErrors(stderr, doc);
             } else {
-                this.errors.delete(docUri);
+                this.errors.delete(doc.uri);
             }
         })
     }
     
-    private analyzeErrors(docUrl: vscode.Uri, fileName: string, stderr: string) {
-        let shortFileName = path.parse(fileName).name;
+    private analyzeErrors(stderr: string, doc: vscode.TextDocument) {
+        let shortFileName = path.parse(doc.fileName).name;
         let diagnostics = stderr.split('\n')
             .filter(line => line.includes(shortFileName))
-            .map(line => this.parseErrorLine(line))
+            .map(line => this.parseErrorLine(line, doc))
             .filter(diagnostic => diagnostic != null);
 
-        this.errors.set(docUrl, diagnostics);
+        this.errors.set(doc.uri, diagnostics);
     }
 
-    private parseErrorLine(line: string): vscode.Diagnostic {
-        let errorInfo = line.match(/\w+\.proto:(\d+):(\d+):\s*(.*)/);
-        if (errorInfo) {
-            let startLine = parseInt(errorInfo[1]) - 1;
-            let startChar = parseInt(errorInfo[2]) - 1;
-            let range = new vscode.Range(startLine, startChar, startLine, line.length);
-            let msg = errorInfo[3];
-            return new vscode.Diagnostic(range, msg, vscode.DiagnosticSeverity.Error);
+    private parseErrorLine(errline: string, doc: vscode.TextDocument): vscode.Diagnostic {
+        let errorInfo = errline.match(/\w+\.proto:(\d+):(\d+):\s*(.*)/);
+        if (!errorInfo) {
+            return null;
         }
-        return null;
+        let startLine = parseInt(errorInfo[1]) - 1;
+        let startCol = parseInt(errorInfo[2]) - 1;
+        
+        // protoc calculates tab width (eight spaces) and returns colunm number.
+        let line = doc.lineAt(startLine);
+        let startChar = 0;
+        let col = 0;
+        for(var c of line.text) {
+            col += ( c === "\t" ? (8 - col % 8): 1 );
+            startChar += 1;
+            if( col >= startCol ) {
+                break;
+            }
+        }
+        let endChar = line.text.length;
+        let tokenEnd = line.text.substr(startChar).match(/[\s;{}\[\],<>()=]/);
+        if (tokenEnd) {
+            endChar = startChar + tokenEnd.index;
+        }
+        let range = new vscode.Range(startLine, startChar, startLine, endChar);
+        let msg = errorInfo[3];
+        return new vscode.Diagnostic(range, msg, vscode.DiagnosticSeverity.Error);
     }
 
 }

--- a/src/proto3Main.ts
+++ b/src/proto3Main.ts
@@ -16,7 +16,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
     let diagnosticProvider = new Proto3LanguageDiagnosticProvider();
     vscode.workspace.onDidSaveTextDocument(event => {
         if (event.languageId == 'proto3') {
-            diagnosticProvider.createDiagnostics(event.uri, event.fileName);
+            diagnosticProvider.createDiagnostics(event);
         }
     });
 


### PR DESCRIPTION
The lines with tab character show the red dash in wrong postion. 

<img width="708" alt="before" src="https://cloud.githubusercontent.com/assets/95236/21746524/54adc7ec-d58b-11e6-85c9-f372c7e9caa7.png">

The syntax error messages from ``protoc``: 

```
tab_indent.proto:7:39: "v1" is already defined in "M1".
tab_indent.proto:8:13: Field number 1 has already been used in "M1" by field "v1".
```

``protoc`` returns each error in ``<.proto>:<line>:<column>`` format. ``vscode.Range`` for error diagnostics expects the character position for start and end  so ``<column>`` number requires translation.

After the fix:

<img width="642" alt="fix" src="https://cloud.githubusercontent.com/assets/95236/21746527/5ef906da-d58b-11e6-83c3-a6c33b76eb97.png">
