### PR TITLE
move changelog into stand-alone file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+## Release Notes
+
+### 0.2.1
+- Fixed issue#26
+
+### 0.2.0
+- Default to look protoc in path (issue#24).
+- Support "Format Document" if clang-format is in path (issue#13).
+
+### 0.1.3
+- Fixed some syntax highlighting issues (issue#2, issue#21, issue#42).
+
+### 0.1.2
+- Fixed some syntax highlighting issues.
+
+### 0.1.1
+- Fixed some syntax highlighting issues.
+- Skip the protoc invocation when it's not configured. 
+
+### 0.1.0
+- Fixed some syntax highlighting issues.
+- Use user and workspace settings instead of a custom settings.json file. 
+- (NOTE: Old users should move the settings.json file into .vscode folder!)
+
+### 0.0.7
+- Fixed syntax highlighting bug of keyword `stream`.
+
+### 0.0.6
+- Fixed some syntax highlighting problems.
+
+### 0.0.5
+- Fixed some bugs.
+
+### 0.0.4
+- Initial release.

--- a/README.md
+++ b/README.md
@@ -100,36 +100,4 @@ Auto-completion not works in some situations.
 
 ## Release Notes
 
-### 0.2.1
-- Fixed issue#26
-
-### 0.2.0
-- Default to look protoc in path (issue#24).
-- Support "Format Document" if clang-format is in path (issue#13).
-
-### 0.1.3
-- Fixed some syntax highlighting issues (issue#2, issue#21, issue#42).
-
-### 0.1.2
-- Fixed some syntax highlighting issues.
-
-### 0.1.1
-- Fixed some syntax highlighting issues.
-- Skip the protoc invocation when it's not configured. 
-
-### 0.1.0
-- Fixed some syntax highlighting issues.
-- Use user and workspace settings instead of a custom settings.json file. 
-- (NOTE: Old users should move the settings.json file into .vscode folder!)
-
-### 0.0.7
-- Fixed syntax highlighting bug of keyword `stream`.
-
-### 0.0.6
-- Fixed some syntax highlighting problems.
-
-### 0.0.5
-- Fixed some bugs.
-
-### 0.0.4
-- Initial release.
+See [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
This PR moves the changelog to its own file, which will be picked up by the vs code marketplace.

https://code.visualstudio.com/docs/extensions/publish-extension#_marketplace-integration