### PR TITLE
Support clang-format style

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ https://github.com/zxh0/vscode-proto3
 - syntax validation.
 - code snippets.
 - code completion.
+- code formatting.
 - brace matching.
 - line and block commenting.
 
@@ -93,6 +94,18 @@ en    | `enum EnumName {}`
 sv    | `service ServiceName {}`
 rpc   | `rpc MethodName (Request) returns (Response);`
 
+## Code Formatting
+
+Support "Format Document" if `clang-format` is in path, including custom `style` options.
+
+By default, `clang-format`'s standard coding style will be used for formatting. To define a custom style or use a supported preset add `"clang-format.style"` in VSCode Settings (`settings.json`)
+
+### Example usage:
+`"clang-format.style": "google"`
+
+This is the equivalent of executing `clang-format -style=google` from the shell.
+
+For further formatting options refer to the [official `clang-format` documentation](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)
 
 ## Known Issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-proto3",
-    "version": "0.1.3",
+    "version": "0.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -22,10 +22,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ansi-cyan": {
@@ -79,8 +79,8 @@
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-flatten": {
@@ -113,7 +113,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -177,7 +177,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -192,7 +192,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "boom": {
@@ -201,7 +201,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -210,7 +210,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -220,9 +220,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -249,11 +249,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "clone": {
@@ -280,9 +280,9 @@
             "integrity": "sha512-DNNEq6JdqBFPzS29TaoqZFPNLn5Xn3XyPFqLIhyBT8Xou4lHQEWzD6FinXoJUfhIfWX3aE1JkRa3cbWCHFbt1g==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
         "co": {
@@ -303,7 +303,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -336,7 +336,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "dashdash": {
@@ -345,7 +345,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -377,7 +377,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "delayed-stream": {
@@ -404,7 +404,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -419,10 +419,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -439,10 +439,10 @@
             "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -452,7 +452,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "end-of-stream": {
@@ -461,7 +461,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -476,13 +476,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -491,7 +491,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -500,7 +500,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             }
         },
         "extend": {
@@ -515,7 +515,7 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
             }
         },
         "extglob": {
@@ -524,7 +524,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -547,9 +547,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -570,7 +570,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -585,11 +585,11 @@
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "first-chunk-stream": {
@@ -610,7 +610,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -625,9 +625,9 @@
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -648,10 +648,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "generate-function": {
@@ -666,7 +666,7 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "getpass": {
@@ -675,7 +675,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -692,12 +692,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -706,8 +706,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -716,7 +716,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -731,7 +731,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -742,8 +742,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -752,14 +752,14 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
                 "glob": {
@@ -768,11 +768,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -787,10 +787,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -805,8 +805,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -817,7 +817,7 @@
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -838,9 +838,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-filter": {
@@ -849,9 +849,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -860,8 +860,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -876,10 +876,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -894,8 +894,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -906,11 +906,11 @@
             "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.79.0",
-                "through2": "2.0.3",
-                "vinyl": "2.0.2"
+                "event-stream": "~3.3.4",
+                "node.extend": "~1.1.2",
+                "request": "~2.79.0",
+                "through2": "~2.0.3",
+                "vinyl": "~2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -931,26 +931,26 @@
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.18",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.2.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "vinyl": {
@@ -959,13 +959,13 @@
                     "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.1",
-                        "is-stream": "1.1.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^1.0.0",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "is-stream": "^1.1.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -976,11 +976,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -1001,8 +1001,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1014,10 +1014,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
         "gulp-untar": {
@@ -1026,11 +1026,11 @@
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3"
+                "event-stream": "~3.3.4",
+                "gulp-util": "~3.0.8",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3"
             }
         },
         "gulp-util": {
@@ -1039,24 +1039,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "clone": {
@@ -1089,8 +1089,8 @@
                     "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1102,13 +1102,13 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -1129,7 +1129,7 @@
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "vinyl": {
@@ -1138,12 +1138,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.1",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -1154,7 +1154,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.1"
+                "glogg": "^1.0.0"
             }
         },
         "har-schema": {
@@ -1169,10 +1169,10 @@
             "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.15.0",
-                "is-my-json-valid": "2.17.2",
-                "pinkie-promise": "2.0.1"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -1181,7 +1181,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -1196,7 +1196,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "hawk": {
@@ -1205,10 +1205,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -1229,9 +1229,9 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -1240,8 +1240,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1274,7 +1274,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -1295,7 +1295,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-my-ip-valid": {
@@ -1310,11 +1310,11 @@
             "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
             "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "is-my-ip-valid": "1.0.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "is-my-ip-valid": "^1.0.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-number": {
@@ -1323,7 +1323,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1332,7 +1332,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1455,7 +1455,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1508,7 +1508,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.5"
             }
         },
         "lodash._basecopy": {
@@ -1571,7 +1571,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -1598,9 +1598,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.restparam": {
@@ -1615,15 +1615,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -1632,8 +1632,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "lru-cache": {
@@ -1654,7 +1654,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -1663,19 +1663,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1684,7 +1684,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "is-extglob": {
@@ -1699,7 +1699,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "kind-of": {
@@ -1708,7 +1708,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1725,7 +1725,7 @@
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "minimatch": {
@@ -1734,7 +1734,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -1788,8 +1788,8 @@
                     "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "minimatch": "0.3.0"
+                        "inherits": "2",
+                        "minimatch": "0.3"
                     }
                 },
                 "minimatch": {
@@ -1798,8 +1798,8 @@
                     "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 },
                 "supports-color": {
@@ -1822,10 +1822,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -1843,7 +1843,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-path": {
@@ -1852,7 +1852,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "npm": {
@@ -1860,121 +1860,121 @@
             "resolved": "https://registry.npmjs.org/npm/-/npm-5.7.1.tgz",
             "integrity": "sha512-r1grvv6mcEt+nlMzMWPc5n/z5q8NNuBWj0TGFp1PBSFCl6ubnAoUGBsucYsnZYT7MOJn0ha1ptEjmdBoAdJ+SA==",
             "requires": {
-                "JSONStream": "1.3.2",
-                "abbrev": "1.1.1",
-                "ansi-regex": "3.0.0",
-                "ansicolors": "0.3.2",
-                "ansistyles": "0.1.3",
-                "aproba": "1.2.0",
-                "archy": "1.0.0",
-                "bin-links": "1.1.0",
-                "bluebird": "3.5.1",
-                "cacache": "10.0.4",
-                "call-limit": "1.1.0",
-                "chownr": "1.0.1",
-                "cli-table2": "0.2.0",
-                "cmd-shim": "2.0.2",
-                "columnify": "1.5.4",
-                "config-chain": "1.1.11",
-                "debuglog": "1.0.1",
-                "detect-indent": "5.0.0",
-                "dezalgo": "1.0.3",
-                "editor": "1.0.0",
-                "find-npm-prefix": "1.0.2",
-                "fs-vacuum": "1.2.10",
-                "fs-write-stream-atomic": "1.0.10",
-                "gentle-fs": "2.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "has-unicode": "2.0.1",
-                "hosted-git-info": "2.5.0",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "ini": "1.3.5",
-                "init-package-json": "1.10.1",
-                "is-cidr": "1.0.0",
-                "lazy-property": "1.0.0",
-                "libcipm": "1.3.3",
-                "libnpx": "9.7.1",
-                "lockfile": "1.0.3",
-                "lodash._baseindexof": "3.1.0",
-                "lodash._baseuniq": "4.6.0",
-                "lodash._bindcallback": "3.0.1",
-                "lodash._cacheindexof": "3.0.2",
-                "lodash._createcache": "3.1.2",
-                "lodash._getnative": "3.9.1",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.restparam": "3.6.1",
-                "lodash.union": "4.6.0",
-                "lodash.uniq": "4.5.0",
-                "lodash.without": "4.4.0",
-                "lru-cache": "4.1.1",
-                "meant": "1.0.1",
-                "mississippi": "2.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "nopt": "4.0.1",
-                "normalize-package-data": "2.4.0",
-                "npm-cache-filename": "1.0.2",
-                "npm-install-checks": "3.0.0",
-                "npm-lifecycle": "2.0.0",
-                "npm-package-arg": "6.0.0",
-                "npm-packlist": "1.1.10",
-                "npm-profile": "3.0.1",
-                "npm-registry-client": "8.5.0",
-                "npm-user-validate": "1.0.0",
-                "npmlog": "4.1.2",
-                "once": "1.4.0",
-                "opener": "1.4.3",
-                "osenv": "0.1.5",
-                "pacote": "7.3.3",
-                "path-is-inside": "1.0.2",
-                "promise-inflight": "1.0.1",
-                "qrcode-terminal": "0.11.0",
-                "query-string": "5.1.0",
-                "qw": "1.0.1",
-                "read": "1.0.7",
-                "read-cmd-shim": "1.0.1",
-                "read-installed": "4.0.3",
-                "read-package-json": "2.0.12",
-                "read-package-tree": "5.1.6",
-                "readable-stream": "2.3.4",
-                "readdir-scoped-modules": "1.0.2",
-                "request": "2.83.0",
-                "retry": "0.10.1",
-                "rimraf": "2.6.2",
-                "safe-buffer": "5.1.1",
-                "semver": "5.5.0",
-                "sha": "2.0.1",
-                "slide": "1.1.6",
-                "sorted-object": "2.0.1",
-                "sorted-union-stream": "2.1.3",
-                "ssri": "5.2.4",
-                "strip-ansi": "4.0.0",
-                "tar": "4.3.3",
-                "text-table": "0.2.0",
+                "JSONStream": "^1.3.2",
+                "abbrev": "~1.1.1",
+                "ansi-regex": "~3.0.0",
+                "ansicolors": "~0.3.2",
+                "ansistyles": "~0.1.3",
+                "aproba": "~1.2.0",
+                "archy": "~1.0.0",
+                "bin-links": "^1.1.0",
+                "bluebird": "~3.5.1",
+                "cacache": "^10.0.4",
+                "call-limit": "~1.1.0",
+                "chownr": "~1.0.1",
+                "cli-table2": "~0.2.0",
+                "cmd-shim": "~2.0.2",
+                "columnify": "~1.5.4",
+                "config-chain": "~1.1.11",
+                "debuglog": "*",
+                "detect-indent": "~5.0.0",
+                "dezalgo": "~1.0.3",
+                "editor": "~1.0.0",
+                "find-npm-prefix": "^1.0.2",
+                "fs-vacuum": "~1.2.10",
+                "fs-write-stream-atomic": "~1.0.10",
+                "gentle-fs": "^2.0.1",
+                "glob": "~7.1.2",
+                "graceful-fs": "~4.1.11",
+                "has-unicode": "~2.0.1",
+                "hosted-git-info": "~2.5.0",
+                "iferr": "~0.1.5",
+                "imurmurhash": "*",
+                "inflight": "~1.0.6",
+                "inherits": "~2.0.3",
+                "ini": "^1.3.5",
+                "init-package-json": "~1.10.1",
+                "is-cidr": "~1.0.0",
+                "lazy-property": "~1.0.0",
+                "libcipm": "^1.3.3",
+                "libnpx": "~9.7.1",
+                "lockfile": "~1.0.3",
+                "lodash._baseindexof": "*",
+                "lodash._baseuniq": "~4.6.0",
+                "lodash._bindcallback": "*",
+                "lodash._cacheindexof": "*",
+                "lodash._createcache": "*",
+                "lodash._getnative": "*",
+                "lodash.clonedeep": "~4.5.0",
+                "lodash.restparam": "*",
+                "lodash.union": "~4.6.0",
+                "lodash.uniq": "~4.5.0",
+                "lodash.without": "~4.4.0",
+                "lru-cache": "~4.1.1",
+                "meant": "~1.0.1",
+                "mississippi": "^2.0.0",
+                "mkdirp": "~0.5.1",
+                "move-concurrently": "^1.0.1",
+                "nopt": "~4.0.1",
+                "normalize-package-data": "~2.4.0",
+                "npm-cache-filename": "~1.0.2",
+                "npm-install-checks": "~3.0.0",
+                "npm-lifecycle": "~2.0.0",
+                "npm-package-arg": "~6.0.0",
+                "npm-packlist": "~1.1.10",
+                "npm-profile": "^3.0.1",
+                "npm-registry-client": "~8.5.0",
+                "npm-user-validate": "~1.0.0",
+                "npmlog": "~4.1.2",
+                "once": "~1.4.0",
+                "opener": "~1.4.3",
+                "osenv": "^0.1.5",
+                "pacote": "^7.3.3",
+                "path-is-inside": "~1.0.2",
+                "promise-inflight": "~1.0.1",
+                "qrcode-terminal": "~0.11.0",
+                "query-string": "^5.1.0",
+                "qw": "~1.0.1",
+                "read": "~1.0.7",
+                "read-cmd-shim": "~1.0.1",
+                "read-installed": "~4.0.3",
+                "read-package-json": "~2.0.12",
+                "read-package-tree": "~5.1.6",
+                "readable-stream": "^2.3.4",
+                "readdir-scoped-modules": "*",
+                "request": "~2.83.0",
+                "retry": "~0.10.1",
+                "rimraf": "~2.6.2",
+                "safe-buffer": "~5.1.1",
+                "semver": "^5.5.0",
+                "sha": "~2.0.1",
+                "slide": "~1.1.6",
+                "sorted-object": "~2.0.1",
+                "sorted-union-stream": "~2.1.3",
+                "ssri": "^5.2.4",
+                "strip-ansi": "~4.0.0",
+                "tar": "^4.3.3",
+                "text-table": "~0.2.0",
                 "uid-number": "0.0.6",
-                "umask": "1.1.0",
-                "unique-filename": "1.1.0",
-                "unpipe": "1.0.0",
-                "update-notifier": "2.3.0",
-                "uuid": "3.2.1",
-                "validate-npm-package-license": "3.0.1",
-                "validate-npm-package-name": "3.0.0",
-                "which": "1.3.0",
-                "worker-farm": "1.5.2",
-                "wrappy": "1.0.2",
-                "write-file-atomic": "2.1.0"
+                "umask": "~1.1.0",
+                "unique-filename": "~1.1.0",
+                "unpipe": "~1.0.0",
+                "update-notifier": "~2.3.0",
+                "uuid": "^3.2.1",
+                "validate-npm-package-license": "*",
+                "validate-npm-package-name": "~3.0.0",
+                "which": "~1.3.0",
+                "worker-farm": "^1.5.2",
+                "wrappy": "~1.0.2",
+                "write-file-atomic": "~2.1.0"
             },
             "dependencies": {
                 "JSONStream": {
                     "version": "1.3.2",
                     "bundled": true,
                     "requires": {
-                        "jsonparse": "1.3.1",
-                        "through": "2.3.8"
+                        "jsonparse": "^1.2.0",
+                        "through": ">=2.2.7 <3"
                     },
                     "dependencies": {
                         "jsonparse": {
@@ -2015,12 +2015,12 @@
                     "version": "1.1.0",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.1",
-                        "cmd-shim": "2.0.2",
-                        "fs-write-stream-atomic": "1.0.10",
-                        "gentle-fs": "2.0.1",
-                        "graceful-fs": "4.1.11",
-                        "slide": "1.1.6"
+                        "bluebird": "^3.5.0",
+                        "cmd-shim": "^2.0.2",
+                        "fs-write-stream-atomic": "^1.0.10",
+                        "gentle-fs": "^2.0.0",
+                        "graceful-fs": "^4.1.11",
+                        "slide": "^1.1.6"
                     }
                 },
                 "bluebird": {
@@ -2031,19 +2031,19 @@
                     "version": "10.0.4",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.1",
-                        "chownr": "1.0.1",
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "lru-cache": "4.1.1",
-                        "mississippi": "2.0.0",
-                        "mkdirp": "0.5.1",
-                        "move-concurrently": "1.0.1",
-                        "promise-inflight": "1.0.1",
-                        "rimraf": "2.6.2",
-                        "ssri": "5.2.4",
-                        "unique-filename": "1.1.0",
-                        "y18n": "4.0.0"
+                        "bluebird": "^3.5.1",
+                        "chownr": "^1.0.1",
+                        "glob": "^7.1.2",
+                        "graceful-fs": "^4.1.11",
+                        "lru-cache": "^4.1.1",
+                        "mississippi": "^2.0.0",
+                        "mkdirp": "^0.5.1",
+                        "move-concurrently": "^1.0.1",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "ssri": "^5.2.4",
+                        "unique-filename": "^1.1.0",
+                        "y18n": "^4.0.0"
                     },
                     "dependencies": {
                         "y18n": {
@@ -2064,9 +2064,9 @@
                     "version": "0.2.0",
                     "bundled": true,
                     "requires": {
-                        "colors": "1.1.2",
-                        "lodash": "3.10.1",
-                        "string-width": "1.0.2"
+                        "colors": "^1.1.2",
+                        "lodash": "^3.10.1",
+                        "string-width": "^1.0.1"
                     },
                     "dependencies": {
                         "colors": {
@@ -2082,9 +2082,9 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             },
                             "dependencies": {
                                 "code-point-at": {
@@ -2095,7 +2095,7 @@
                                     "version": "1.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "number-is-nan": "1.0.1"
+                                        "number-is-nan": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "number-is-nan": {
@@ -2108,7 +2108,7 @@
                                     "version": "3.0.1",
                                     "bundled": true,
                                     "requires": {
-                                        "ansi-regex": "2.1.1"
+                                        "ansi-regex": "^2.0.0"
                                     },
                                     "dependencies": {
                                         "ansi-regex": {
@@ -2125,23 +2125,23 @@
                     "version": "2.0.2",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "mkdirp": "0.5.1"
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "~0.5.0"
                     }
                 },
                 "columnify": {
                     "version": "1.5.4",
                     "bundled": true,
                     "requires": {
-                        "strip-ansi": "3.0.1",
-                        "wcwidth": "1.0.1"
+                        "strip-ansi": "^3.0.0",
+                        "wcwidth": "^1.0.0"
                     },
                     "dependencies": {
                         "strip-ansi": {
                             "version": "3.0.1",
                             "bundled": true,
                             "requires": {
-                                "ansi-regex": "2.1.1"
+                                "ansi-regex": "^2.0.0"
                             },
                             "dependencies": {
                                 "ansi-regex": {
@@ -2154,14 +2154,14 @@
                             "version": "1.0.1",
                             "bundled": true,
                             "requires": {
-                                "defaults": "1.0.3"
+                                "defaults": "^1.0.3"
                             },
                             "dependencies": {
                                 "defaults": {
                                     "version": "1.0.3",
                                     "bundled": true,
                                     "requires": {
-                                        "clone": "1.0.2"
+                                        "clone": "^1.0.2"
                                     },
                                     "dependencies": {
                                         "clone": {
@@ -2178,8 +2178,8 @@
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "ini": "1.3.5",
-                        "proto-list": "1.2.4"
+                        "ini": "^1.3.4",
+                        "proto-list": "~1.2.1"
                     },
                     "dependencies": {
                         "proto-list": {
@@ -2200,8 +2200,8 @@
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "asap": "2.0.5",
-                        "wrappy": "1.0.2"
+                        "asap": "^2.0.0",
+                        "wrappy": "1"
                     },
                     "dependencies": {
                         "asap": {
@@ -2222,45 +2222,45 @@
                     "version": "1.2.10",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "path-is-inside": "1.0.2",
-                        "rimraf": "2.6.2"
+                        "graceful-fs": "^4.1.2",
+                        "path-is-inside": "^1.0.1",
+                        "rimraf": "^2.5.2"
                     }
                 },
                 "fs-write-stream-atomic": {
                     "version": "1.0.10",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "iferr": "0.1.5",
-                        "imurmurhash": "0.1.4",
-                        "readable-stream": "2.3.4"
+                        "graceful-fs": "^4.1.2",
+                        "iferr": "^0.1.5",
+                        "imurmurhash": "^0.1.4",
+                        "readable-stream": "1 || 2"
                     }
                 },
                 "gentle-fs": {
                     "version": "2.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "fs-vacuum": "1.2.10",
-                        "graceful-fs": "4.1.11",
-                        "iferr": "0.1.5",
-                        "mkdirp": "0.5.1",
-                        "path-is-inside": "1.0.2",
-                        "read-cmd-shim": "1.0.1",
-                        "slide": "1.1.6"
+                        "aproba": "^1.1.2",
+                        "fs-vacuum": "^1.2.10",
+                        "graceful-fs": "^4.1.11",
+                        "iferr": "^0.1.5",
+                        "mkdirp": "^0.5.1",
+                        "path-is-inside": "^1.0.2",
+                        "read-cmd-shim": "^1.0.1",
+                        "slide": "^1.1.6"
                     }
                 },
                 "glob": {
                     "version": "7.1.2",
                     "bundled": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     },
                     "dependencies": {
                         "fs.realpath": {
@@ -2271,14 +2271,14 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "requires": {
-                                "brace-expansion": "1.1.8"
+                                "brace-expansion": "^1.1.7"
                             },
                             "dependencies": {
                                 "brace-expansion": {
                                     "version": "1.1.8",
                                     "bundled": true,
                                     "requires": {
-                                        "balanced-match": "1.0.0",
+                                        "balanced-match": "^1.0.0",
                                         "concat-map": "0.0.1"
                                     },
                                     "dependencies": {
@@ -2324,8 +2324,8 @@
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -2340,31 +2340,31 @@
                     "version": "1.10.1",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "npm-package-arg": "5.1.2",
-                        "promzard": "0.3.0",
-                        "read": "1.0.7",
-                        "read-package-json": "2.0.12",
-                        "semver": "5.5.0",
-                        "validate-npm-package-license": "3.0.1",
-                        "validate-npm-package-name": "3.0.0"
+                        "glob": "^7.1.1",
+                        "npm-package-arg": "^4.0.0 || ^5.0.0",
+                        "promzard": "^0.3.0",
+                        "read": "~1.0.1",
+                        "read-package-json": "1 || 2",
+                        "semver": "2.x || 3.x || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1",
+                        "validate-npm-package-name": "^3.0.0"
                     },
                     "dependencies": {
                         "npm-package-arg": {
                             "version": "5.1.2",
                             "bundled": true,
                             "requires": {
-                                "hosted-git-info": "2.5.0",
-                                "osenv": "0.1.5",
-                                "semver": "5.5.0",
-                                "validate-npm-package-name": "3.0.0"
+                                "hosted-git-info": "^2.4.2",
+                                "osenv": "^0.1.4",
+                                "semver": "^5.1.0",
+                                "validate-npm-package-name": "^3.0.0"
                             }
                         },
                         "promzard": {
                             "version": "0.3.0",
                             "bundled": true,
                             "requires": {
-                                "read": "1.0.7"
+                                "read": "1"
                             }
                         }
                     }
@@ -2390,19 +2390,19 @@
                     "version": "1.3.3",
                     "bundled": true,
                     "requires": {
-                        "bin-links": "1.1.0",
-                        "bluebird": "3.5.1",
-                        "find-npm-prefix": "1.0.2",
-                        "graceful-fs": "4.1.11",
-                        "lock-verify": "2.0.0",
-                        "npm-lifecycle": "2.0.0",
-                        "npm-logical-tree": "1.2.1",
-                        "npm-package-arg": "6.0.0",
-                        "pacote": "7.3.3",
-                        "protoduck": "5.0.0",
-                        "read-package-json": "2.0.12",
-                        "rimraf": "2.6.2",
-                        "worker-farm": "1.5.2"
+                        "bin-links": "^1.1.0",
+                        "bluebird": "^3.5.1",
+                        "find-npm-prefix": "^1.0.2",
+                        "graceful-fs": "^4.1.11",
+                        "lock-verify": "^2.0.0",
+                        "npm-lifecycle": "^2.0.0",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.0.0",
+                        "pacote": "^7.3.3",
+                        "protoduck": "^5.0.0",
+                        "read-package-json": "^2.0.12",
+                        "rimraf": "^2.6.2",
+                        "worker-farm": "^1.5.2"
                     },
                     "dependencies": {
                         "find-npm-prefix": {
@@ -2413,18 +2413,18 @@
                             "version": "2.0.0",
                             "bundled": true,
                             "requires": {
-                                "npm-package-arg": "5.1.2",
-                                "semver": "5.5.0"
+                                "npm-package-arg": "^5.1.2",
+                                "semver": "^5.4.1"
                             },
                             "dependencies": {
                                 "npm-package-arg": {
                                     "version": "5.1.2",
                                     "bundled": true,
                                     "requires": {
-                                        "hosted-git-info": "2.5.0",
-                                        "osenv": "0.1.5",
-                                        "semver": "5.5.0",
-                                        "validate-npm-package-name": "3.0.0"
+                                        "hosted-git-info": "^2.4.2",
+                                        "osenv": "^0.1.4",
+                                        "semver": "^5.1.0",
+                                        "validate-npm-package-name": "^3.0.0"
                                     }
                                 }
                             }
@@ -2437,7 +2437,7 @@
                             "version": "5.0.0",
                             "bundled": true,
                             "requires": {
-                                "genfun": "4.0.1"
+                                "genfun": "^4.0.1"
                             },
                             "dependencies": {
                                 "genfun": {
@@ -2450,15 +2450,15 @@
                             "version": "1.5.2",
                             "bundled": true,
                             "requires": {
-                                "errno": "0.1.7",
-                                "xtend": "4.0.1"
+                                "errno": "^0.1.4",
+                                "xtend": "^4.0.1"
                             },
                             "dependencies": {
                                 "errno": {
                                     "version": "0.1.7",
                                     "bundled": true,
                                     "requires": {
-                                        "prr": "1.0.1"
+                                        "prr": "~1.0.1"
                                     },
                                     "dependencies": {
                                         "prr": {
@@ -2479,14 +2479,14 @@
                     "version": "9.7.1",
                     "bundled": true,
                     "requires": {
-                        "dotenv": "4.0.0",
-                        "npm-package-arg": "5.1.2",
-                        "rimraf": "2.6.2",
-                        "safe-buffer": "5.1.1",
-                        "update-notifier": "2.3.0",
-                        "which": "1.3.0",
-                        "y18n": "3.2.1",
-                        "yargs": "8.0.2"
+                        "dotenv": "^4.0.0",
+                        "npm-package-arg": "^5.1.2",
+                        "rimraf": "^2.6.1",
+                        "safe-buffer": "^5.1.0",
+                        "update-notifier": "^2.2.0",
+                        "which": "^1.2.14",
+                        "y18n": "^3.2.1",
+                        "yargs": "^8.0.2"
                     },
                     "dependencies": {
                         "dotenv": {
@@ -2497,10 +2497,10 @@
                             "version": "5.1.2",
                             "bundled": true,
                             "requires": {
-                                "hosted-git-info": "2.5.0",
-                                "osenv": "0.1.5",
-                                "semver": "5.5.0",
-                                "validate-npm-package-name": "3.0.0"
+                                "hosted-git-info": "^2.4.2",
+                                "osenv": "^0.1.4",
+                                "semver": "^5.1.0",
+                                "validate-npm-package-name": "^3.0.0"
                             }
                         },
                         "y18n": {
@@ -2511,19 +2511,19 @@
                             "version": "8.0.2",
                             "bundled": true,
                             "requires": {
-                                "camelcase": "4.1.0",
-                                "cliui": "3.2.0",
-                                "decamelize": "1.2.0",
-                                "get-caller-file": "1.0.2",
-                                "os-locale": "2.1.0",
-                                "read-pkg-up": "2.0.0",
-                                "require-directory": "2.1.1",
-                                "require-main-filename": "1.0.1",
-                                "set-blocking": "2.0.0",
-                                "string-width": "2.1.1",
-                                "which-module": "2.0.0",
-                                "y18n": "3.2.1",
-                                "yargs-parser": "7.0.0"
+                                "camelcase": "^4.1.0",
+                                "cliui": "^3.2.0",
+                                "decamelize": "^1.1.1",
+                                "get-caller-file": "^1.0.1",
+                                "os-locale": "^2.0.0",
+                                "read-pkg-up": "^2.0.0",
+                                "require-directory": "^2.1.1",
+                                "require-main-filename": "^1.0.1",
+                                "set-blocking": "^2.0.0",
+                                "string-width": "^2.0.0",
+                                "which-module": "^2.0.0",
+                                "y18n": "^3.2.1",
+                                "yargs-parser": "^7.0.0"
                             },
                             "dependencies": {
                                 "camelcase": {
@@ -2534,18 +2534,18 @@
                                     "version": "3.2.0",
                                     "bundled": true,
                                     "requires": {
-                                        "string-width": "1.0.2",
-                                        "strip-ansi": "3.0.1",
-                                        "wrap-ansi": "2.1.0"
+                                        "string-width": "^1.0.1",
+                                        "strip-ansi": "^3.0.1",
+                                        "wrap-ansi": "^2.0.0"
                                     },
                                     "dependencies": {
                                         "string-width": {
                                             "version": "1.0.2",
                                             "bundled": true,
                                             "requires": {
-                                                "code-point-at": "1.1.0",
-                                                "is-fullwidth-code-point": "1.0.0",
-                                                "strip-ansi": "3.0.1"
+                                                "code-point-at": "^1.0.0",
+                                                "is-fullwidth-code-point": "^1.0.0",
+                                                "strip-ansi": "^3.0.0"
                                             },
                                             "dependencies": {
                                                 "code-point-at": {
@@ -2556,7 +2556,7 @@
                                                     "version": "1.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "number-is-nan": "1.0.1"
+                                                        "number-is-nan": "^1.0.0"
                                                     },
                                                     "dependencies": {
                                                         "number-is-nan": {
@@ -2571,7 +2571,7 @@
                                             "version": "3.0.1",
                                             "bundled": true,
                                             "requires": {
-                                                "ansi-regex": "2.1.1"
+                                                "ansi-regex": "^2.0.0"
                                             },
                                             "dependencies": {
                                                 "ansi-regex": {
@@ -2584,8 +2584,8 @@
                                             "version": "2.1.0",
                                             "bundled": true,
                                             "requires": {
-                                                "string-width": "1.0.2",
-                                                "strip-ansi": "3.0.1"
+                                                "string-width": "^1.0.1",
+                                                "strip-ansi": "^3.0.1"
                                             }
                                         }
                                     }
@@ -2602,38 +2602,38 @@
                                     "version": "2.1.0",
                                     "bundled": true,
                                     "requires": {
-                                        "execa": "0.7.0",
-                                        "lcid": "1.0.0",
-                                        "mem": "1.1.0"
+                                        "execa": "^0.7.0",
+                                        "lcid": "^1.0.0",
+                                        "mem": "^1.1.0"
                                     },
                                     "dependencies": {
                                         "execa": {
                                             "version": "0.7.0",
                                             "bundled": true,
                                             "requires": {
-                                                "cross-spawn": "5.1.0",
-                                                "get-stream": "3.0.0",
-                                                "is-stream": "1.1.0",
-                                                "npm-run-path": "2.0.2",
-                                                "p-finally": "1.0.0",
-                                                "signal-exit": "3.0.2",
-                                                "strip-eof": "1.0.0"
+                                                "cross-spawn": "^5.0.1",
+                                                "get-stream": "^3.0.0",
+                                                "is-stream": "^1.1.0",
+                                                "npm-run-path": "^2.0.0",
+                                                "p-finally": "^1.0.0",
+                                                "signal-exit": "^3.0.0",
+                                                "strip-eof": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "cross-spawn": {
                                                     "version": "5.1.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "lru-cache": "4.1.1",
-                                                        "shebang-command": "1.2.0",
-                                                        "which": "1.3.0"
+                                                        "lru-cache": "^4.0.1",
+                                                        "shebang-command": "^1.2.0",
+                                                        "which": "^1.2.9"
                                                     },
                                                     "dependencies": {
                                                         "shebang-command": {
                                                             "version": "1.2.0",
                                                             "bundled": true,
                                                             "requires": {
-                                                                "shebang-regex": "1.0.0"
+                                                                "shebang-regex": "^1.0.0"
                                                             },
                                                             "dependencies": {
                                                                 "shebang-regex": {
@@ -2656,7 +2656,7 @@
                                                     "version": "2.0.2",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "path-key": "2.0.1"
+                                                        "path-key": "^2.0.0"
                                                     },
                                                     "dependencies": {
                                                         "path-key": {
@@ -2683,7 +2683,7 @@
                                             "version": "1.0.0",
                                             "bundled": true,
                                             "requires": {
-                                                "invert-kv": "1.0.0"
+                                                "invert-kv": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "invert-kv": {
@@ -2696,7 +2696,7 @@
                                             "version": "1.1.0",
                                             "bundled": true,
                                             "requires": {
-                                                "mimic-fn": "1.1.0"
+                                                "mimic-fn": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "mimic-fn": {
@@ -2711,30 +2711,30 @@
                                     "version": "2.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "find-up": "2.1.0",
-                                        "read-pkg": "2.0.0"
+                                        "find-up": "^2.0.0",
+                                        "read-pkg": "^2.0.0"
                                     },
                                     "dependencies": {
                                         "find-up": {
                                             "version": "2.1.0",
                                             "bundled": true,
                                             "requires": {
-                                                "locate-path": "2.0.0"
+                                                "locate-path": "^2.0.0"
                                             },
                                             "dependencies": {
                                                 "locate-path": {
                                                     "version": "2.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "p-locate": "2.0.0",
-                                                        "path-exists": "3.0.0"
+                                                        "p-locate": "^2.0.0",
+                                                        "path-exists": "^3.0.0"
                                                     },
                                                     "dependencies": {
                                                         "p-locate": {
                                                             "version": "2.0.0",
                                                             "bundled": true,
                                                             "requires": {
-                                                                "p-limit": "1.1.0"
+                                                                "p-limit": "^1.1.0"
                                                             },
                                                             "dependencies": {
                                                                 "p-limit": {
@@ -2755,33 +2755,33 @@
                                             "version": "2.0.0",
                                             "bundled": true,
                                             "requires": {
-                                                "load-json-file": "2.0.0",
-                                                "normalize-package-data": "2.4.0",
-                                                "path-type": "2.0.0"
+                                                "load-json-file": "^2.0.0",
+                                                "normalize-package-data": "^2.3.2",
+                                                "path-type": "^2.0.0"
                                             },
                                             "dependencies": {
                                                 "load-json-file": {
                                                     "version": "2.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "graceful-fs": "4.1.11",
-                                                        "parse-json": "2.2.0",
-                                                        "pify": "2.3.0",
-                                                        "strip-bom": "3.0.0"
+                                                        "graceful-fs": "^4.1.2",
+                                                        "parse-json": "^2.2.0",
+                                                        "pify": "^2.0.0",
+                                                        "strip-bom": "^3.0.0"
                                                     },
                                                     "dependencies": {
                                                         "parse-json": {
                                                             "version": "2.2.0",
                                                             "bundled": true,
                                                             "requires": {
-                                                                "error-ex": "1.3.1"
+                                                                "error-ex": "^1.2.0"
                                                             },
                                                             "dependencies": {
                                                                 "error-ex": {
                                                                     "version": "1.3.1",
                                                                     "bundled": true,
                                                                     "requires": {
-                                                                        "is-arrayish": "0.2.1"
+                                                                        "is-arrayish": "^0.2.1"
                                                                     },
                                                                     "dependencies": {
                                                                         "is-arrayish": {
@@ -2806,7 +2806,7 @@
                                                     "version": "2.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "pify": "2.3.0"
+                                                        "pify": "^2.0.0"
                                                     },
                                                     "dependencies": {
                                                         "pify": {
@@ -2835,8 +2835,8 @@
                                     "version": "2.1.1",
                                     "bundled": true,
                                     "requires": {
-                                        "is-fullwidth-code-point": "2.0.0",
-                                        "strip-ansi": "4.0.0"
+                                        "is-fullwidth-code-point": "^2.0.0",
+                                        "strip-ansi": "^4.0.0"
                                     },
                                     "dependencies": {
                                         "is-fullwidth-code-point": {
@@ -2853,7 +2853,7 @@
                                     "version": "7.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "camelcase": "4.1.0"
+                                        "camelcase": "^4.1.0"
                                     }
                                 }
                             }
@@ -2872,8 +2872,8 @@
                     "version": "4.6.0",
                     "bundled": true,
                     "requires": {
-                        "lodash._createset": "4.0.3",
-                        "lodash._root": "3.0.1"
+                        "lodash._createset": "~4.0.0",
+                        "lodash._root": "~3.0.0"
                     },
                     "dependencies": {
                         "lodash._createset": {
@@ -2898,7 +2898,7 @@
                     "version": "3.1.2",
                     "bundled": true,
                     "requires": {
-                        "lodash._getnative": "3.9.1"
+                        "lodash._getnative": "^3.0.0"
                     }
                 },
                 "lodash._getnative": {
@@ -2929,8 +2929,8 @@
                     "version": "4.1.1",
                     "bundled": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     },
                     "dependencies": {
                         "pseudomap": {
@@ -2951,25 +2951,25 @@
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "concat-stream": "1.6.0",
-                        "duplexify": "3.5.3",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.2",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "2.0.1",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^2.0.1",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
                     },
                     "dependencies": {
                         "concat-stream": {
                             "version": "1.6.0",
                             "bundled": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4",
-                                "typedarray": "0.0.6"
+                                "inherits": "^2.0.3",
+                                "readable-stream": "^2.2.2",
+                                "typedarray": "^0.0.6"
                             },
                             "dependencies": {
                                 "typedarray": {
@@ -2982,10 +2982,10 @@
                             "version": "3.5.3",
                             "bundled": true,
                             "requires": {
-                                "end-of-stream": "1.4.1",
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4",
-                                "stream-shift": "1.0.0"
+                                "end-of-stream": "^1.0.0",
+                                "inherits": "^2.0.1",
+                                "readable-stream": "^2.0.0",
+                                "stream-shift": "^1.0.0"
                             },
                             "dependencies": {
                                 "stream-shift": {
@@ -2998,32 +2998,32 @@
                             "version": "1.4.1",
                             "bundled": true,
                             "requires": {
-                                "once": "1.4.0"
+                                "once": "^1.4.0"
                             }
                         },
                         "flush-write-stream": {
                             "version": "1.0.2",
                             "bundled": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4"
+                                "inherits": "^2.0.1",
+                                "readable-stream": "^2.0.4"
                             }
                         },
                         "from2": {
                             "version": "2.3.0",
                             "bundled": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4"
+                                "inherits": "^2.0.1",
+                                "readable-stream": "^2.0.0"
                             }
                         },
                         "parallel-transform": {
                             "version": "1.1.0",
                             "bundled": true,
                             "requires": {
-                                "cyclist": "0.2.2",
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4"
+                                "cyclist": "~0.2.2",
+                                "inherits": "^2.0.3",
+                                "readable-stream": "^2.1.5"
                             },
                             "dependencies": {
                                 "cyclist": {
@@ -3036,25 +3036,25 @@
                             "version": "2.0.1",
                             "bundled": true,
                             "requires": {
-                                "end-of-stream": "1.4.1",
-                                "once": "1.4.0"
+                                "end-of-stream": "^1.1.0",
+                                "once": "^1.3.1"
                             }
                         },
                         "pumpify": {
                             "version": "1.4.0",
                             "bundled": true,
                             "requires": {
-                                "duplexify": "3.5.3",
-                                "inherits": "2.0.3",
-                                "pump": "2.0.1"
+                                "duplexify": "^3.5.3",
+                                "inherits": "^2.0.3",
+                                "pump": "^2.0.0"
                             }
                         },
                         "stream-each": {
                             "version": "1.2.2",
                             "bundled": true,
                             "requires": {
-                                "end-of-stream": "1.4.1",
-                                "stream-shift": "1.0.0"
+                                "end-of-stream": "^1.1.0",
+                                "stream-shift": "^1.0.0"
                             },
                             "dependencies": {
                                 "stream-shift": {
@@ -3067,8 +3067,8 @@
                             "version": "2.0.3",
                             "bundled": true,
                             "requires": {
-                                "readable-stream": "2.3.4",
-                                "xtend": "4.0.1"
+                                "readable-stream": "^2.1.5",
+                                "xtend": "~4.0.1"
                             },
                             "dependencies": {
                                 "xtend": {
@@ -3096,31 +3096,31 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "copy-concurrently": "1.0.5",
-                        "fs-write-stream-atomic": "1.0.10",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2",
-                        "run-queue": "1.0.3"
+                        "aproba": "^1.1.1",
+                        "copy-concurrently": "^1.0.0",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.3"
                     },
                     "dependencies": {
                         "copy-concurrently": {
                             "version": "1.0.5",
                             "bundled": true,
                             "requires": {
-                                "aproba": "1.2.0",
-                                "fs-write-stream-atomic": "1.0.10",
-                                "iferr": "0.1.5",
-                                "mkdirp": "0.5.1",
-                                "rimraf": "2.6.2",
-                                "run-queue": "1.0.3"
+                                "aproba": "^1.1.1",
+                                "fs-write-stream-atomic": "^1.0.8",
+                                "iferr": "^0.1.5",
+                                "mkdirp": "^0.5.1",
+                                "rimraf": "^2.5.4",
+                                "run-queue": "^1.0.0"
                             }
                         },
                         "run-queue": {
                             "version": "1.0.3",
                             "bundled": true,
                             "requires": {
-                                "aproba": "1.2.0"
+                                "aproba": "^1.1.1"
                             }
                         }
                     }
@@ -3129,43 +3129,43 @@
                     "version": "3.6.2",
                     "bundled": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "minimatch": "3.0.4",
-                        "mkdirp": "0.5.1",
-                        "nopt": "3.0.6",
-                        "npmlog": "4.1.2",
-                        "osenv": "0.1.5",
-                        "request": "2.83.0",
-                        "rimraf": "2.6.2",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "which": "1.3.0"
+                        "fstream": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "graceful-fs": "^4.1.2",
+                        "minimatch": "^3.0.2",
+                        "mkdirp": "^0.5.0",
+                        "nopt": "2 || 3",
+                        "npmlog": "0 || 1 || 2 || 3 || 4",
+                        "osenv": "0",
+                        "request": "2",
+                        "rimraf": "2",
+                        "semver": "~5.3.0",
+                        "tar": "^2.0.0",
+                        "which": "1"
                     },
                     "dependencies": {
                         "fstream": {
                             "version": "1.0.11",
                             "bundled": true,
                             "requires": {
-                                "graceful-fs": "4.1.11",
-                                "inherits": "2.0.3",
-                                "mkdirp": "0.5.1",
-                                "rimraf": "2.6.2"
+                                "graceful-fs": "^4.1.2",
+                                "inherits": "~2.0.0",
+                                "mkdirp": ">=0.5 0",
+                                "rimraf": "2"
                             }
                         },
                         "minimatch": {
                             "version": "3.0.4",
                             "bundled": true,
                             "requires": {
-                                "brace-expansion": "1.1.8"
+                                "brace-expansion": "^1.1.7"
                             },
                             "dependencies": {
                                 "brace-expansion": {
                                     "version": "1.1.8",
                                     "bundled": true,
                                     "requires": {
-                                        "balanced-match": "1.0.0",
+                                        "balanced-match": "^1.0.0",
                                         "concat-map": "0.0.1"
                                     },
                                     "dependencies": {
@@ -3185,7 +3185,7 @@
                             "version": "3.0.6",
                             "bundled": true,
                             "requires": {
-                                "abbrev": "1.1.1"
+                                "abbrev": "1"
                             }
                         },
                         "semver": {
@@ -3196,16 +3196,16 @@
                             "version": "2.2.1",
                             "bundled": true,
                             "requires": {
-                                "block-stream": "0.0.9",
-                                "fstream": "1.0.11",
-                                "inherits": "2.0.3"
+                                "block-stream": "*",
+                                "fstream": "^1.0.2",
+                                "inherits": "2"
                             },
                             "dependencies": {
                                 "block-stream": {
                                     "version": "0.0.9",
                                     "bundled": true,
                                     "requires": {
-                                        "inherits": "2.0.3"
+                                        "inherits": "~2.0.0"
                                     }
                                 }
                             }
@@ -3216,25 +3216,25 @@
                     "version": "4.0.1",
                     "bundled": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "normalize-package-data": {
                     "version": "2.4.0",
                     "bundled": true,
                     "requires": {
-                        "hosted-git-info": "2.5.0",
-                        "is-builtin-module": "1.0.0",
-                        "semver": "5.5.0",
-                        "validate-npm-package-license": "3.0.1"
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
                     },
                     "dependencies": {
                         "is-builtin-module": {
                             "version": "1.0.0",
                             "bundled": true,
                             "requires": {
-                                "builtin-modules": "1.1.1"
+                                "builtin-modules": "^1.0.0"
                             },
                             "dependencies": {
                                 "builtin-modules": {
@@ -3253,21 +3253,21 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "semver": "5.5.0"
+                        "semver": "^2.3.0 || 3.x || 4 || 5"
                     }
                 },
                 "npm-lifecycle": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "byline": "5.0.0",
-                        "graceful-fs": "4.1.11",
-                        "node-gyp": "3.6.2",
-                        "resolve-from": "4.0.0",
-                        "slide": "1.1.6",
+                        "byline": "^5.0.0",
+                        "graceful-fs": "^4.1.11",
+                        "node-gyp": "^3.6.2",
+                        "resolve-from": "^4.0.0",
+                        "slide": "^1.1.6",
                         "uid-number": "0.0.6",
-                        "umask": "1.1.0",
-                        "which": "1.3.0"
+                        "umask": "^1.1.0",
+                        "which": "^1.3.0"
                     },
                     "dependencies": {
                         "byline": {
@@ -3284,39 +3284,39 @@
                     "version": "6.0.0",
                     "bundled": true,
                     "requires": {
-                        "hosted-git-info": "2.5.0",
-                        "osenv": "0.1.5",
-                        "semver": "5.5.0",
-                        "validate-npm-package-name": "3.0.0"
+                        "hosted-git-info": "^2.5.0",
+                        "osenv": "^0.1.4",
+                        "semver": "^5.4.1",
+                        "validate-npm-package-name": "^3.0.0"
                     }
                 },
                 "npm-packlist": {
                     "version": "1.1.10",
                     "bundled": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     },
                     "dependencies": {
                         "ignore-walk": {
                             "version": "3.0.1",
                             "bundled": true,
                             "requires": {
-                                "minimatch": "3.0.4"
+                                "minimatch": "^3.0.4"
                             },
                             "dependencies": {
                                 "minimatch": {
                                     "version": "3.0.4",
                                     "bundled": true,
                                     "requires": {
-                                        "brace-expansion": "1.1.8"
+                                        "brace-expansion": "^1.1.7"
                                     },
                                     "dependencies": {
                                         "brace-expansion": {
                                             "version": "1.1.8",
                                             "bundled": true,
                                             "requires": {
-                                                "balanced-match": "1.0.0",
+                                                "balanced-match": "^1.0.0",
                                                 "concat-map": "0.0.1"
                                             },
                                             "dependencies": {
@@ -3344,39 +3344,39 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "make-fetch-happen": "2.6.0"
+                        "aproba": "^1.1.2",
+                        "make-fetch-happen": "^2.5.0"
                     },
                     "dependencies": {
                         "make-fetch-happen": {
                             "version": "2.6.0",
                             "bundled": true,
                             "requires": {
-                                "agentkeepalive": "3.3.0",
-                                "cacache": "10.0.4",
-                                "http-cache-semantics": "3.8.1",
-                                "http-proxy-agent": "2.0.0",
-                                "https-proxy-agent": "2.1.1",
-                                "lru-cache": "4.1.1",
-                                "mississippi": "1.3.1",
-                                "node-fetch-npm": "2.0.2",
-                                "promise-retry": "1.1.1",
-                                "socks-proxy-agent": "3.0.1",
-                                "ssri": "5.2.4"
+                                "agentkeepalive": "^3.3.0",
+                                "cacache": "^10.0.0",
+                                "http-cache-semantics": "^3.8.0",
+                                "http-proxy-agent": "^2.0.0",
+                                "https-proxy-agent": "^2.1.0",
+                                "lru-cache": "^4.1.1",
+                                "mississippi": "^1.2.0",
+                                "node-fetch-npm": "^2.0.2",
+                                "promise-retry": "^1.1.1",
+                                "socks-proxy-agent": "^3.0.1",
+                                "ssri": "^5.0.0"
                             },
                             "dependencies": {
                                 "agentkeepalive": {
                                     "version": "3.3.0",
                                     "bundled": true,
                                     "requires": {
-                                        "humanize-ms": "1.2.1"
+                                        "humanize-ms": "^1.2.1"
                                     },
                                     "dependencies": {
                                         "humanize-ms": {
                                             "version": "1.2.1",
                                             "bundled": true,
                                             "requires": {
-                                                "ms": "2.1.1"
+                                                "ms": "^2.0.0"
                                             },
                                             "dependencies": {
                                                 "ms": {
@@ -3395,22 +3395,22 @@
                                     "version": "2.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "agent-base": "4.2.0",
-                                        "debug": "2.6.9"
+                                        "agent-base": "4",
+                                        "debug": "2"
                                     },
                                     "dependencies": {
                                         "agent-base": {
                                             "version": "4.2.0",
                                             "bundled": true,
                                             "requires": {
-                                                "es6-promisify": "5.0.0"
+                                                "es6-promisify": "^5.0.0"
                                             },
                                             "dependencies": {
                                                 "es6-promisify": {
                                                     "version": "5.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "es6-promise": "4.2.4"
+                                                        "es6-promise": "^4.0.3"
                                                     },
                                                     "dependencies": {
                                                         "es6-promise": {
@@ -3440,22 +3440,22 @@
                                     "version": "2.1.1",
                                     "bundled": true,
                                     "requires": {
-                                        "agent-base": "4.2.0",
-                                        "debug": "3.1.0"
+                                        "agent-base": "^4.1.0",
+                                        "debug": "^3.1.0"
                                     },
                                     "dependencies": {
                                         "agent-base": {
                                             "version": "4.2.0",
                                             "bundled": true,
                                             "requires": {
-                                                "es6-promisify": "5.0.0"
+                                                "es6-promisify": "^5.0.0"
                                             },
                                             "dependencies": {
                                                 "es6-promisify": {
                                                     "version": "5.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "es6-promise": "4.2.4"
+                                                        "es6-promise": "^4.0.3"
                                                     },
                                                     "dependencies": {
                                                         "es6-promise": {
@@ -3485,25 +3485,25 @@
                                     "version": "1.3.1",
                                     "bundled": true,
                                     "requires": {
-                                        "concat-stream": "1.6.0",
-                                        "duplexify": "3.5.3",
-                                        "end-of-stream": "1.4.1",
-                                        "flush-write-stream": "1.0.2",
-                                        "from2": "2.3.0",
-                                        "parallel-transform": "1.1.0",
-                                        "pump": "1.0.3",
-                                        "pumpify": "1.4.0",
-                                        "stream-each": "1.2.2",
-                                        "through2": "2.0.3"
+                                        "concat-stream": "^1.5.0",
+                                        "duplexify": "^3.4.2",
+                                        "end-of-stream": "^1.1.0",
+                                        "flush-write-stream": "^1.0.0",
+                                        "from2": "^2.1.0",
+                                        "parallel-transform": "^1.1.0",
+                                        "pump": "^1.0.0",
+                                        "pumpify": "^1.3.3",
+                                        "stream-each": "^1.1.0",
+                                        "through2": "^2.0.0"
                                     },
                                     "dependencies": {
                                         "concat-stream": {
                                             "version": "1.6.0",
                                             "bundled": true,
                                             "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4",
-                                                "typedarray": "0.0.6"
+                                                "inherits": "^2.0.3",
+                                                "readable-stream": "^2.2.2",
+                                                "typedarray": "^0.0.6"
                                             },
                                             "dependencies": {
                                                 "typedarray": {
@@ -3516,10 +3516,10 @@
                                             "version": "3.5.3",
                                             "bundled": true,
                                             "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4",
-                                                "stream-shift": "1.0.0"
+                                                "end-of-stream": "^1.0.0",
+                                                "inherits": "^2.0.1",
+                                                "readable-stream": "^2.0.0",
+                                                "stream-shift": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "stream-shift": {
@@ -3532,32 +3532,32 @@
                                             "version": "1.4.1",
                                             "bundled": true,
                                             "requires": {
-                                                "once": "1.4.0"
+                                                "once": "^1.4.0"
                                             }
                                         },
                                         "flush-write-stream": {
                                             "version": "1.0.2",
                                             "bundled": true,
                                             "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
+                                                "inherits": "^2.0.1",
+                                                "readable-stream": "^2.0.4"
                                             }
                                         },
                                         "from2": {
                                             "version": "2.3.0",
                                             "bundled": true,
                                             "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
+                                                "inherits": "^2.0.1",
+                                                "readable-stream": "^2.0.0"
                                             }
                                         },
                                         "parallel-transform": {
                                             "version": "1.1.0",
                                             "bundled": true,
                                             "requires": {
-                                                "cyclist": "0.2.2",
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
+                                                "cyclist": "~0.2.2",
+                                                "inherits": "^2.0.3",
+                                                "readable-stream": "^2.1.5"
                                             },
                                             "dependencies": {
                                                 "cyclist": {
@@ -3570,25 +3570,25 @@
                                             "version": "1.0.3",
                                             "bundled": true,
                                             "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "once": "1.4.0"
+                                                "end-of-stream": "^1.1.0",
+                                                "once": "^1.3.1"
                                             }
                                         },
                                         "pumpify": {
                                             "version": "1.4.0",
                                             "bundled": true,
                                             "requires": {
-                                                "duplexify": "3.5.3",
-                                                "inherits": "2.0.3",
-                                                "pump": "2.0.1"
+                                                "duplexify": "^3.5.3",
+                                                "inherits": "^2.0.3",
+                                                "pump": "^2.0.0"
                                             },
                                             "dependencies": {
                                                 "pump": {
                                                     "version": "2.0.1",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "end-of-stream": "1.4.1",
-                                                        "once": "1.4.0"
+                                                        "end-of-stream": "^1.1.0",
+                                                        "once": "^1.3.1"
                                                     }
                                                 }
                                             }
@@ -3597,8 +3597,8 @@
                                             "version": "1.2.2",
                                             "bundled": true,
                                             "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "stream-shift": "1.0.0"
+                                                "end-of-stream": "^1.1.0",
+                                                "stream-shift": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "stream-shift": {
@@ -3611,8 +3611,8 @@
                                             "version": "2.0.3",
                                             "bundled": true,
                                             "requires": {
-                                                "readable-stream": "2.3.4",
-                                                "xtend": "4.0.1"
+                                                "readable-stream": "^2.1.5",
+                                                "xtend": "~4.0.1"
                                             },
                                             "dependencies": {
                                                 "xtend": {
@@ -3627,16 +3627,16 @@
                                     "version": "2.0.2",
                                     "bundled": true,
                                     "requires": {
-                                        "encoding": "0.1.12",
-                                        "json-parse-better-errors": "1.0.1",
-                                        "safe-buffer": "5.1.1"
+                                        "encoding": "^0.1.11",
+                                        "json-parse-better-errors": "^1.0.0",
+                                        "safe-buffer": "^5.1.1"
                                     },
                                     "dependencies": {
                                         "encoding": {
                                             "version": "0.1.12",
                                             "bundled": true,
                                             "requires": {
-                                                "iconv-lite": "0.4.19"
+                                                "iconv-lite": "~0.4.13"
                                             },
                                             "dependencies": {
                                                 "iconv-lite": {
@@ -3655,8 +3655,8 @@
                                     "version": "1.1.1",
                                     "bundled": true,
                                     "requires": {
-                                        "err-code": "1.1.2",
-                                        "retry": "0.10.1"
+                                        "err-code": "^1.0.0",
+                                        "retry": "^0.10.0"
                                     },
                                     "dependencies": {
                                         "err-code": {
@@ -3669,22 +3669,22 @@
                                     "version": "3.0.1",
                                     "bundled": true,
                                     "requires": {
-                                        "agent-base": "4.2.0",
-                                        "socks": "1.1.10"
+                                        "agent-base": "^4.1.0",
+                                        "socks": "^1.1.10"
                                     },
                                     "dependencies": {
                                         "agent-base": {
                                             "version": "4.2.0",
                                             "bundled": true,
                                             "requires": {
-                                                "es6-promisify": "5.0.0"
+                                                "es6-promisify": "^5.0.0"
                                             },
                                             "dependencies": {
                                                 "es6-promisify": {
                                                     "version": "5.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "es6-promise": "4.2.4"
+                                                        "es6-promise": "^4.0.3"
                                                     },
                                                     "dependencies": {
                                                         "es6-promise": {
@@ -3699,8 +3699,8 @@
                                             "version": "1.1.10",
                                             "bundled": true,
                                             "requires": {
-                                                "ip": "1.1.5",
-                                                "smart-buffer": "1.1.15"
+                                                "ip": "^1.1.4",
+                                                "smart-buffer": "^1.0.13"
                                             },
                                             "dependencies": {
                                                 "ip": {
@@ -3723,26 +3723,26 @@
                     "version": "8.5.0",
                     "bundled": true,
                     "requires": {
-                        "concat-stream": "1.6.0",
-                        "graceful-fs": "4.1.11",
-                        "normalize-package-data": "2.4.0",
-                        "npm-package-arg": "5.1.2",
-                        "npmlog": "4.1.2",
-                        "once": "1.4.0",
-                        "request": "2.83.0",
-                        "retry": "0.10.1",
-                        "semver": "5.5.0",
-                        "slide": "1.1.6",
-                        "ssri": "4.1.6"
+                        "concat-stream": "^1.5.2",
+                        "graceful-fs": "^4.1.6",
+                        "normalize-package-data": "~1.0.1 || ^2.0.0",
+                        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
+                        "npmlog": "2 || ^3.1.0 || ^4.0.0",
+                        "once": "^1.3.3",
+                        "request": "^2.74.0",
+                        "retry": "^0.10.0",
+                        "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+                        "slide": "^1.1.3",
+                        "ssri": "^4.1.2"
                     },
                     "dependencies": {
                         "concat-stream": {
                             "version": "1.6.0",
                             "bundled": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4",
-                                "typedarray": "0.0.6"
+                                "inherits": "^2.0.3",
+                                "readable-stream": "^2.2.2",
+                                "typedarray": "^0.0.6"
                             },
                             "dependencies": {
                                 "typedarray": {
@@ -3755,17 +3755,17 @@
                             "version": "5.1.2",
                             "bundled": true,
                             "requires": {
-                                "hosted-git-info": "2.5.0",
-                                "osenv": "0.1.5",
-                                "semver": "5.5.0",
-                                "validate-npm-package-name": "3.0.0"
+                                "hosted-git-info": "^2.4.2",
+                                "osenv": "^0.1.4",
+                                "semver": "^5.1.0",
+                                "validate-npm-package-name": "^3.0.0"
                             }
                         },
                         "ssri": {
                             "version": "4.1.6",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.1"
+                                "safe-buffer": "^5.1.0"
                             }
                         }
                     }
@@ -3778,18 +3778,18 @@
                     "version": "4.1.2",
                     "bundled": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     },
                     "dependencies": {
                         "are-we-there-yet": {
                             "version": "1.1.4",
                             "bundled": true,
                             "requires": {
-                                "delegates": "1.0.0",
-                                "readable-stream": "2.3.4"
+                                "delegates": "^1.0.0",
+                                "readable-stream": "^2.0.6"
                             },
                             "dependencies": {
                                 "delegates": {
@@ -3806,14 +3806,14 @@
                             "version": "2.7.4",
                             "bundled": true,
                             "requires": {
-                                "aproba": "1.2.0",
-                                "console-control-strings": "1.1.0",
-                                "has-unicode": "2.0.1",
-                                "object-assign": "4.1.1",
-                                "signal-exit": "3.0.2",
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wide-align": "1.1.2"
+                                "aproba": "^1.0.3",
+                                "console-control-strings": "^1.0.0",
+                                "has-unicode": "^2.0.0",
+                                "object-assign": "^4.1.0",
+                                "signal-exit": "^3.0.0",
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wide-align": "^1.1.0"
                             },
                             "dependencies": {
                                 "object-assign": {
@@ -3828,9 +3828,9 @@
                                     "version": "1.0.2",
                                     "bundled": true,
                                     "requires": {
-                                        "code-point-at": "1.1.0",
-                                        "is-fullwidth-code-point": "1.0.0",
-                                        "strip-ansi": "3.0.1"
+                                        "code-point-at": "^1.0.0",
+                                        "is-fullwidth-code-point": "^1.0.0",
+                                        "strip-ansi": "^3.0.0"
                                     },
                                     "dependencies": {
                                         "code-point-at": {
@@ -3841,7 +3841,7 @@
                                             "version": "1.0.0",
                                             "bundled": true,
                                             "requires": {
-                                                "number-is-nan": "1.0.1"
+                                                "number-is-nan": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "number-is-nan": {
@@ -3856,7 +3856,7 @@
                                     "version": "3.0.1",
                                     "bundled": true,
                                     "requires": {
-                                        "ansi-regex": "2.1.1"
+                                        "ansi-regex": "^2.0.0"
                                     },
                                     "dependencies": {
                                         "ansi-regex": {
@@ -3869,7 +3869,7 @@
                                     "version": "1.1.2",
                                     "bundled": true,
                                     "requires": {
-                                        "string-width": "1.0.2"
+                                        "string-width": "^1.0.2"
                                     }
                                 }
                             }
@@ -3884,7 +3884,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "opener": {
@@ -3895,8 +3895,8 @@
                     "version": "0.1.5",
                     "bundled": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     },
                     "dependencies": {
                         "os-homedir": {
@@ -3913,28 +3913,28 @@
                     "version": "7.3.3",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.1",
-                        "cacache": "10.0.4",
-                        "get-stream": "3.0.0",
-                        "glob": "7.1.2",
-                        "lru-cache": "4.1.1",
-                        "make-fetch-happen": "2.6.0",
-                        "minimatch": "3.0.4",
-                        "mississippi": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "npm-package-arg": "6.0.0",
-                        "npm-packlist": "1.1.10",
-                        "npm-pick-manifest": "2.1.0",
-                        "osenv": "0.1.5",
-                        "promise-inflight": "1.0.1",
-                        "promise-retry": "1.1.1",
-                        "protoduck": "5.0.0",
-                        "safe-buffer": "5.1.1",
-                        "semver": "5.5.0",
-                        "ssri": "5.2.4",
-                        "tar": "4.3.3",
-                        "unique-filename": "1.1.0",
-                        "which": "1.3.0"
+                        "bluebird": "^3.5.1",
+                        "cacache": "^10.0.2",
+                        "get-stream": "^3.0.0",
+                        "glob": "^7.1.2",
+                        "lru-cache": "^4.1.1",
+                        "make-fetch-happen": "^2.6.0",
+                        "minimatch": "^3.0.4",
+                        "mississippi": "^2.0.0",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-package-arg": "^6.0.0",
+                        "npm-packlist": "^1.1.10",
+                        "npm-pick-manifest": "^2.1.0",
+                        "osenv": "^0.1.4",
+                        "promise-inflight": "^1.0.1",
+                        "promise-retry": "^1.1.1",
+                        "protoduck": "^5.0.0",
+                        "safe-buffer": "^5.1.1",
+                        "semver": "^5.5.0",
+                        "ssri": "^5.2.1",
+                        "tar": "^4.3.3",
+                        "unique-filename": "^1.1.0",
+                        "which": "^1.3.0"
                     },
                     "dependencies": {
                         "get-stream": {
@@ -3945,31 +3945,31 @@
                             "version": "2.6.0",
                             "bundled": true,
                             "requires": {
-                                "agentkeepalive": "3.3.0",
-                                "cacache": "10.0.4",
-                                "http-cache-semantics": "3.8.1",
-                                "http-proxy-agent": "2.0.0",
-                                "https-proxy-agent": "2.1.1",
-                                "lru-cache": "4.1.1",
-                                "mississippi": "1.3.1",
-                                "node-fetch-npm": "2.0.2",
-                                "promise-retry": "1.1.1",
-                                "socks-proxy-agent": "3.0.1",
-                                "ssri": "5.2.4"
+                                "agentkeepalive": "^3.3.0",
+                                "cacache": "^10.0.0",
+                                "http-cache-semantics": "^3.8.0",
+                                "http-proxy-agent": "^2.0.0",
+                                "https-proxy-agent": "^2.1.0",
+                                "lru-cache": "^4.1.1",
+                                "mississippi": "^1.2.0",
+                                "node-fetch-npm": "^2.0.2",
+                                "promise-retry": "^1.1.1",
+                                "socks-proxy-agent": "^3.0.1",
+                                "ssri": "^5.0.0"
                             },
                             "dependencies": {
                                 "agentkeepalive": {
                                     "version": "3.3.0",
                                     "bundled": true,
                                     "requires": {
-                                        "humanize-ms": "1.2.1"
+                                        "humanize-ms": "^1.2.1"
                                     },
                                     "dependencies": {
                                         "humanize-ms": {
                                             "version": "1.2.1",
                                             "bundled": true,
                                             "requires": {
-                                                "ms": "2.1.1"
+                                                "ms": "^2.0.0"
                                             },
                                             "dependencies": {
                                                 "ms": {
@@ -3988,22 +3988,22 @@
                                     "version": "2.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "agent-base": "4.2.0",
-                                        "debug": "2.6.9"
+                                        "agent-base": "4",
+                                        "debug": "2"
                                     },
                                     "dependencies": {
                                         "agent-base": {
                                             "version": "4.2.0",
                                             "bundled": true,
                                             "requires": {
-                                                "es6-promisify": "5.0.0"
+                                                "es6-promisify": "^5.0.0"
                                             },
                                             "dependencies": {
                                                 "es6-promisify": {
                                                     "version": "5.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "es6-promise": "4.2.4"
+                                                        "es6-promise": "^4.0.3"
                                                     },
                                                     "dependencies": {
                                                         "es6-promise": {
@@ -4033,22 +4033,22 @@
                                     "version": "2.1.1",
                                     "bundled": true,
                                     "requires": {
-                                        "agent-base": "4.2.0",
-                                        "debug": "3.1.0"
+                                        "agent-base": "^4.1.0",
+                                        "debug": "^3.1.0"
                                     },
                                     "dependencies": {
                                         "agent-base": {
                                             "version": "4.2.0",
                                             "bundled": true,
                                             "requires": {
-                                                "es6-promisify": "5.0.0"
+                                                "es6-promisify": "^5.0.0"
                                             },
                                             "dependencies": {
                                                 "es6-promisify": {
                                                     "version": "5.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "es6-promise": "4.2.4"
+                                                        "es6-promise": "^4.0.3"
                                                     },
                                                     "dependencies": {
                                                         "es6-promise": {
@@ -4078,25 +4078,25 @@
                                     "version": "1.3.1",
                                     "bundled": true,
                                     "requires": {
-                                        "concat-stream": "1.6.0",
-                                        "duplexify": "3.5.3",
-                                        "end-of-stream": "1.4.1",
-                                        "flush-write-stream": "1.0.2",
-                                        "from2": "2.3.0",
-                                        "parallel-transform": "1.1.0",
-                                        "pump": "1.0.3",
-                                        "pumpify": "1.4.0",
-                                        "stream-each": "1.2.2",
-                                        "through2": "2.0.3"
+                                        "concat-stream": "^1.5.0",
+                                        "duplexify": "^3.4.2",
+                                        "end-of-stream": "^1.1.0",
+                                        "flush-write-stream": "^1.0.0",
+                                        "from2": "^2.1.0",
+                                        "parallel-transform": "^1.1.0",
+                                        "pump": "^1.0.0",
+                                        "pumpify": "^1.3.3",
+                                        "stream-each": "^1.1.0",
+                                        "through2": "^2.0.0"
                                     },
                                     "dependencies": {
                                         "concat-stream": {
                                             "version": "1.6.0",
                                             "bundled": true,
                                             "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4",
-                                                "typedarray": "0.0.6"
+                                                "inherits": "^2.0.3",
+                                                "readable-stream": "^2.2.2",
+                                                "typedarray": "^0.0.6"
                                             },
                                             "dependencies": {
                                                 "typedarray": {
@@ -4109,10 +4109,10 @@
                                             "version": "3.5.3",
                                             "bundled": true,
                                             "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4",
-                                                "stream-shift": "1.0.0"
+                                                "end-of-stream": "^1.0.0",
+                                                "inherits": "^2.0.1",
+                                                "readable-stream": "^2.0.0",
+                                                "stream-shift": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "stream-shift": {
@@ -4125,32 +4125,32 @@
                                             "version": "1.4.1",
                                             "bundled": true,
                                             "requires": {
-                                                "once": "1.4.0"
+                                                "once": "^1.4.0"
                                             }
                                         },
                                         "flush-write-stream": {
                                             "version": "1.0.2",
                                             "bundled": true,
                                             "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
+                                                "inherits": "^2.0.1",
+                                                "readable-stream": "^2.0.4"
                                             }
                                         },
                                         "from2": {
                                             "version": "2.3.0",
                                             "bundled": true,
                                             "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
+                                                "inherits": "^2.0.1",
+                                                "readable-stream": "^2.0.0"
                                             }
                                         },
                                         "parallel-transform": {
                                             "version": "1.1.0",
                                             "bundled": true,
                                             "requires": {
-                                                "cyclist": "0.2.2",
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
+                                                "cyclist": "~0.2.2",
+                                                "inherits": "^2.0.3",
+                                                "readable-stream": "^2.1.5"
                                             },
                                             "dependencies": {
                                                 "cyclist": {
@@ -4163,25 +4163,25 @@
                                             "version": "1.0.3",
                                             "bundled": true,
                                             "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "once": "1.4.0"
+                                                "end-of-stream": "^1.1.0",
+                                                "once": "^1.3.1"
                                             }
                                         },
                                         "pumpify": {
                                             "version": "1.4.0",
                                             "bundled": true,
                                             "requires": {
-                                                "duplexify": "3.5.3",
-                                                "inherits": "2.0.3",
-                                                "pump": "2.0.1"
+                                                "duplexify": "^3.5.3",
+                                                "inherits": "^2.0.3",
+                                                "pump": "^2.0.0"
                                             },
                                             "dependencies": {
                                                 "pump": {
                                                     "version": "2.0.1",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "end-of-stream": "1.4.1",
-                                                        "once": "1.4.0"
+                                                        "end-of-stream": "^1.1.0",
+                                                        "once": "^1.3.1"
                                                     }
                                                 }
                                             }
@@ -4190,8 +4190,8 @@
                                             "version": "1.2.2",
                                             "bundled": true,
                                             "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "stream-shift": "1.0.0"
+                                                "end-of-stream": "^1.1.0",
+                                                "stream-shift": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "stream-shift": {
@@ -4204,8 +4204,8 @@
                                             "version": "2.0.3",
                                             "bundled": true,
                                             "requires": {
-                                                "readable-stream": "2.3.4",
-                                                "xtend": "4.0.1"
+                                                "readable-stream": "^2.1.5",
+                                                "xtend": "~4.0.1"
                                             },
                                             "dependencies": {
                                                 "xtend": {
@@ -4220,16 +4220,16 @@
                                     "version": "2.0.2",
                                     "bundled": true,
                                     "requires": {
-                                        "encoding": "0.1.12",
-                                        "json-parse-better-errors": "1.0.1",
-                                        "safe-buffer": "5.1.1"
+                                        "encoding": "^0.1.11",
+                                        "json-parse-better-errors": "^1.0.0",
+                                        "safe-buffer": "^5.1.1"
                                     },
                                     "dependencies": {
                                         "encoding": {
                                             "version": "0.1.12",
                                             "bundled": true,
                                             "requires": {
-                                                "iconv-lite": "0.4.19"
+                                                "iconv-lite": "~0.4.13"
                                             },
                                             "dependencies": {
                                                 "iconv-lite": {
@@ -4248,22 +4248,22 @@
                                     "version": "3.0.1",
                                     "bundled": true,
                                     "requires": {
-                                        "agent-base": "4.2.0",
-                                        "socks": "1.1.10"
+                                        "agent-base": "^4.1.0",
+                                        "socks": "^1.1.10"
                                     },
                                     "dependencies": {
                                         "agent-base": {
                                             "version": "4.2.0",
                                             "bundled": true,
                                             "requires": {
-                                                "es6-promisify": "5.0.0"
+                                                "es6-promisify": "^5.0.0"
                                             },
                                             "dependencies": {
                                                 "es6-promisify": {
                                                     "version": "5.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "es6-promise": "4.2.4"
+                                                        "es6-promise": "^4.0.3"
                                                     },
                                                     "dependencies": {
                                                         "es6-promise": {
@@ -4278,8 +4278,8 @@
                                             "version": "1.1.10",
                                             "bundled": true,
                                             "requires": {
-                                                "ip": "1.1.5",
-                                                "smart-buffer": "1.1.15"
+                                                "ip": "^1.1.4",
+                                                "smart-buffer": "^1.0.13"
                                             },
                                             "dependencies": {
                                                 "ip": {
@@ -4300,14 +4300,14 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "requires": {
-                                "brace-expansion": "1.1.11"
+                                "brace-expansion": "^1.1.7"
                             },
                             "dependencies": {
                                 "brace-expansion": {
                                     "version": "1.1.11",
                                     "bundled": true,
                                     "requires": {
-                                        "balanced-match": "1.0.0",
+                                        "balanced-match": "^1.0.0",
                                         "concat-map": "0.0.1"
                                     },
                                     "dependencies": {
@@ -4327,25 +4327,25 @@
                             "version": "2.0.0",
                             "bundled": true,
                             "requires": {
-                                "concat-stream": "1.6.0",
-                                "duplexify": "3.5.3",
-                                "end-of-stream": "1.4.1",
-                                "flush-write-stream": "1.0.2",
-                                "from2": "2.3.0",
-                                "parallel-transform": "1.1.0",
-                                "pump": "2.0.1",
-                                "pumpify": "1.4.0",
-                                "stream-each": "1.2.2",
-                                "through2": "2.0.3"
+                                "concat-stream": "^1.5.0",
+                                "duplexify": "^3.4.2",
+                                "end-of-stream": "^1.1.0",
+                                "flush-write-stream": "^1.0.0",
+                                "from2": "^2.1.0",
+                                "parallel-transform": "^1.1.0",
+                                "pump": "^2.0.1",
+                                "pumpify": "^1.3.3",
+                                "stream-each": "^1.1.0",
+                                "through2": "^2.0.0"
                             },
                             "dependencies": {
                                 "concat-stream": {
                                     "version": "1.6.0",
                                     "bundled": true,
                                     "requires": {
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4",
-                                        "typedarray": "0.0.6"
+                                        "inherits": "^2.0.3",
+                                        "readable-stream": "^2.2.2",
+                                        "typedarray": "^0.0.6"
                                     },
                                     "dependencies": {
                                         "typedarray": {
@@ -4358,10 +4358,10 @@
                                     "version": "3.5.3",
                                     "bundled": true,
                                     "requires": {
-                                        "end-of-stream": "1.4.1",
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4",
-                                        "stream-shift": "1.0.0"
+                                        "end-of-stream": "^1.0.0",
+                                        "inherits": "^2.0.1",
+                                        "readable-stream": "^2.0.0",
+                                        "stream-shift": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "stream-shift": {
@@ -4374,32 +4374,32 @@
                                     "version": "1.4.1",
                                     "bundled": true,
                                     "requires": {
-                                        "once": "1.4.0"
+                                        "once": "^1.4.0"
                                     }
                                 },
                                 "flush-write-stream": {
                                     "version": "1.0.2",
                                     "bundled": true,
                                     "requires": {
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4"
+                                        "inherits": "^2.0.1",
+                                        "readable-stream": "^2.0.4"
                                     }
                                 },
                                 "from2": {
                                     "version": "2.3.0",
                                     "bundled": true,
                                     "requires": {
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4"
+                                        "inherits": "^2.0.1",
+                                        "readable-stream": "^2.0.0"
                                     }
                                 },
                                 "parallel-transform": {
                                     "version": "1.1.0",
                                     "bundled": true,
                                     "requires": {
-                                        "cyclist": "0.2.2",
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4"
+                                        "cyclist": "~0.2.2",
+                                        "inherits": "^2.0.3",
+                                        "readable-stream": "^2.1.5"
                                     },
                                     "dependencies": {
                                         "cyclist": {
@@ -4412,25 +4412,25 @@
                                     "version": "2.0.1",
                                     "bundled": true,
                                     "requires": {
-                                        "end-of-stream": "1.4.1",
-                                        "once": "1.4.0"
+                                        "end-of-stream": "^1.1.0",
+                                        "once": "^1.3.1"
                                     }
                                 },
                                 "pumpify": {
                                     "version": "1.4.0",
                                     "bundled": true,
                                     "requires": {
-                                        "duplexify": "3.5.3",
-                                        "inherits": "2.0.3",
-                                        "pump": "2.0.1"
+                                        "duplexify": "^3.5.3",
+                                        "inherits": "^2.0.3",
+                                        "pump": "^2.0.0"
                                     }
                                 },
                                 "stream-each": {
                                     "version": "1.2.2",
                                     "bundled": true,
                                     "requires": {
-                                        "end-of-stream": "1.4.1",
-                                        "stream-shift": "1.0.0"
+                                        "end-of-stream": "^1.1.0",
+                                        "stream-shift": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "stream-shift": {
@@ -4443,8 +4443,8 @@
                                     "version": "2.0.3",
                                     "bundled": true,
                                     "requires": {
-                                        "readable-stream": "2.3.4",
-                                        "xtend": "4.0.1"
+                                        "readable-stream": "^2.1.5",
+                                        "xtend": "~4.0.1"
                                     },
                                     "dependencies": {
                                         "xtend": {
@@ -4459,16 +4459,16 @@
                             "version": "2.1.0",
                             "bundled": true,
                             "requires": {
-                                "npm-package-arg": "6.0.0",
-                                "semver": "5.5.0"
+                                "npm-package-arg": "^6.0.0",
+                                "semver": "^5.4.1"
                             }
                         },
                         "promise-retry": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "err-code": "1.1.2",
-                                "retry": "0.10.1"
+                                "err-code": "^1.0.0",
+                                "retry": "^0.10.0"
                             },
                             "dependencies": {
                                 "err-code": {
@@ -4481,7 +4481,7 @@
                             "version": "5.0.0",
                             "bundled": true,
                             "requires": {
-                                "genfun": "4.0.1"
+                                "genfun": "^4.0.1"
                             },
                             "dependencies": {
                                 "genfun": {
@@ -4512,9 +4512,9 @@
                     "version": "5.1.0",
                     "bundled": true,
                     "requires": {
-                        "decode-uri-component": "0.2.0",
-                        "object-assign": "4.1.1",
-                        "strict-uri-encode": "1.1.0"
+                        "decode-uri-component": "^0.2.0",
+                        "object-assign": "^4.1.0",
+                        "strict-uri-encode": "^1.0.0"
                     },
                     "dependencies": {
                         "decode-uri-component": {
@@ -4539,7 +4539,7 @@
                     "version": "1.0.7",
                     "bundled": true,
                     "requires": {
-                        "mute-stream": "0.0.7"
+                        "mute-stream": "~0.0.4"
                     },
                     "dependencies": {
                         "mute-stream": {
@@ -4552,20 +4552,20 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "graceful-fs": "^4.1.2"
                     }
                 },
                 "read-installed": {
                     "version": "4.0.3",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "graceful-fs": "4.1.11",
-                        "read-package-json": "2.0.12",
-                        "readdir-scoped-modules": "1.0.2",
-                        "semver": "5.5.0",
-                        "slide": "1.1.6",
-                        "util-extend": "1.0.3"
+                        "debuglog": "^1.0.1",
+                        "graceful-fs": "^4.1.2",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "slide": "~1.1.3",
+                        "util-extend": "^1.0.1"
                     },
                     "dependencies": {
                         "util-extend": {
@@ -4578,11 +4578,11 @@
                     "version": "2.0.12",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "json-parse-better-errors": "1.0.1",
-                        "normalize-package-data": "2.4.0",
-                        "slash": "1.0.0"
+                        "glob": "^7.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "json-parse-better-errors": "^1.0.0",
+                        "normalize-package-data": "^2.0.0",
+                        "slash": "^1.0.0"
                     },
                     "dependencies": {
                         "json-parse-better-errors": {
@@ -4599,24 +4599,24 @@
                     "version": "5.1.6",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "once": "1.4.0",
-                        "read-package-json": "2.0.12",
-                        "readdir-scoped-modules": "1.0.2"
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "once": "^1.3.0",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0"
                     }
                 },
                 "readable-stream": {
                     "version": "2.3.4",
                     "bundled": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     },
                     "dependencies": {
                         "core-util-is": {
@@ -4635,7 +4635,7 @@
                             "version": "1.0.3",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.1"
+                                "safe-buffer": "~5.1.0"
                             }
                         },
                         "util-deprecate": {
@@ -4648,38 +4648,38 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "graceful-fs": "4.1.11",
-                        "once": "1.4.0"
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "graceful-fs": "^4.1.2",
+                        "once": "^1.3.0"
                     }
                 },
                 "request": {
                     "version": "2.83.0",
                     "bundled": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.1",
-                        "har-validator": "5.0.3",
-                        "hawk": "6.0.2",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.1",
-                        "safe-buffer": "5.1.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.2.1"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.6.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.1",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.1",
+                        "har-validator": "~5.0.3",
+                        "hawk": "~6.0.2",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.17",
+                        "oauth-sign": "~0.8.2",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.1",
+                        "safe-buffer": "^5.1.1",
+                        "stringstream": "~0.0.5",
+                        "tough-cookie": "~2.3.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.1.0"
                     },
                     "dependencies": {
                         "aws-sign2": {
@@ -4698,7 +4698,7 @@
                             "version": "1.0.5",
                             "bundled": true,
                             "requires": {
-                                "delayed-stream": "1.0.0"
+                                "delayed-stream": "~1.0.0"
                             },
                             "dependencies": {
                                 "delayed-stream": {
@@ -4719,9 +4719,9 @@
                             "version": "2.3.1",
                             "bundled": true,
                             "requires": {
-                                "asynckit": "0.4.0",
-                                "combined-stream": "1.0.5",
-                                "mime-types": "2.1.17"
+                                "asynckit": "^0.4.0",
+                                "combined-stream": "^1.0.5",
+                                "mime-types": "^2.1.12"
                             },
                             "dependencies": {
                                 "asynckit": {
@@ -4734,18 +4734,18 @@
                             "version": "5.0.3",
                             "bundled": true,
                             "requires": {
-                                "ajv": "5.2.3",
-                                "har-schema": "2.0.0"
+                                "ajv": "^5.1.0",
+                                "har-schema": "^2.0.0"
                             },
                             "dependencies": {
                                 "ajv": {
                                     "version": "5.2.3",
                                     "bundled": true,
                                     "requires": {
-                                        "co": "4.6.0",
-                                        "fast-deep-equal": "1.0.0",
-                                        "json-schema-traverse": "0.3.1",
-                                        "json-stable-stringify": "1.0.1"
+                                        "co": "^4.6.0",
+                                        "fast-deep-equal": "^1.0.0",
+                                        "json-schema-traverse": "^0.3.0",
+                                        "json-stable-stringify": "^1.0.1"
                                     },
                                     "dependencies": {
                                         "co": {
@@ -4764,7 +4764,7 @@
                                             "version": "1.0.1",
                                             "bundled": true,
                                             "requires": {
-                                                "jsonify": "0.0.0"
+                                                "jsonify": "~0.0.0"
                                             },
                                             "dependencies": {
                                                 "jsonify": {
@@ -4785,31 +4785,31 @@
                             "version": "6.0.2",
                             "bundled": true,
                             "requires": {
-                                "boom": "4.3.1",
-                                "cryptiles": "3.1.2",
-                                "hoek": "4.2.0",
-                                "sntp": "2.0.2"
+                                "boom": "4.x.x",
+                                "cryptiles": "3.x.x",
+                                "hoek": "4.x.x",
+                                "sntp": "2.x.x"
                             },
                             "dependencies": {
                                 "boom": {
                                     "version": "4.3.1",
                                     "bundled": true,
                                     "requires": {
-                                        "hoek": "4.2.0"
+                                        "hoek": "4.x.x"
                                     }
                                 },
                                 "cryptiles": {
                                     "version": "3.1.2",
                                     "bundled": true,
                                     "requires": {
-                                        "boom": "5.2.0"
+                                        "boom": "5.x.x"
                                     },
                                     "dependencies": {
                                         "boom": {
                                             "version": "5.2.0",
                                             "bundled": true,
                                             "requires": {
-                                                "hoek": "4.2.0"
+                                                "hoek": "4.x.x"
                                             }
                                         }
                                     }
@@ -4822,7 +4822,7 @@
                                     "version": "2.0.2",
                                     "bundled": true,
                                     "requires": {
-                                        "hoek": "4.2.0"
+                                        "hoek": "4.x.x"
                                     }
                                 }
                             }
@@ -4831,9 +4831,9 @@
                             "version": "1.2.0",
                             "bundled": true,
                             "requires": {
-                                "assert-plus": "1.0.0",
-                                "jsprim": "1.4.1",
-                                "sshpk": "1.13.1"
+                                "assert-plus": "^1.0.0",
+                                "jsprim": "^1.2.2",
+                                "sshpk": "^1.7.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
@@ -4862,9 +4862,9 @@
                                             "version": "1.10.0",
                                             "bundled": true,
                                             "requires": {
-                                                "assert-plus": "1.0.0",
+                                                "assert-plus": "^1.0.0",
                                                 "core-util-is": "1.0.2",
-                                                "extsprintf": "1.3.0"
+                                                "extsprintf": "^1.2.0"
                                             },
                                             "dependencies": {
                                                 "core-util-is": {
@@ -4879,14 +4879,14 @@
                                     "version": "1.13.1",
                                     "bundled": true,
                                     "requires": {
-                                        "asn1": "0.2.3",
-                                        "assert-plus": "1.0.0",
-                                        "bcrypt-pbkdf": "1.0.1",
-                                        "dashdash": "1.14.1",
-                                        "ecc-jsbn": "0.1.1",
-                                        "getpass": "0.1.7",
-                                        "jsbn": "0.1.1",
-                                        "tweetnacl": "0.14.5"
+                                        "asn1": "~0.2.3",
+                                        "assert-plus": "^1.0.0",
+                                        "bcrypt-pbkdf": "^1.0.0",
+                                        "dashdash": "^1.12.0",
+                                        "ecc-jsbn": "~0.1.1",
+                                        "getpass": "^0.1.1",
+                                        "jsbn": "~0.1.0",
+                                        "tweetnacl": "~0.14.0"
                                     },
                                     "dependencies": {
                                         "asn1": {
@@ -4898,14 +4898,14 @@
                                             "bundled": true,
                                             "optional": true,
                                             "requires": {
-                                                "tweetnacl": "0.14.5"
+                                                "tweetnacl": "^0.14.3"
                                             }
                                         },
                                         "dashdash": {
                                             "version": "1.14.1",
                                             "bundled": true,
                                             "requires": {
-                                                "assert-plus": "1.0.0"
+                                                "assert-plus": "^1.0.0"
                                             }
                                         },
                                         "ecc-jsbn": {
@@ -4913,14 +4913,14 @@
                                             "bundled": true,
                                             "optional": true,
                                             "requires": {
-                                                "jsbn": "0.1.1"
+                                                "jsbn": "~0.1.0"
                                             }
                                         },
                                         "getpass": {
                                             "version": "0.1.7",
                                             "bundled": true,
                                             "requires": {
-                                                "assert-plus": "1.0.0"
+                                                "assert-plus": "^1.0.0"
                                             }
                                         },
                                         "jsbn": {
@@ -4953,7 +4953,7 @@
                             "version": "2.1.17",
                             "bundled": true,
                             "requires": {
-                                "mime-db": "1.30.0"
+                                "mime-db": "~1.30.0"
                             },
                             "dependencies": {
                                 "mime-db": {
@@ -4982,7 +4982,7 @@
                             "version": "2.3.3",
                             "bundled": true,
                             "requires": {
-                                "punycode": "1.4.1"
+                                "punycode": "^1.4.1"
                             },
                             "dependencies": {
                                 "punycode": {
@@ -4995,7 +4995,7 @@
                             "version": "0.6.0",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.1"
+                                "safe-buffer": "^5.0.1"
                             }
                         }
                     }
@@ -5008,7 +5008,7 @@
                     "version": "2.6.2",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -5023,8 +5023,8 @@
                     "version": "2.0.1",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "readable-stream": "2.3.4"
+                        "graceful-fs": "^4.1.2",
+                        "readable-stream": "^2.0.2"
                     }
                 },
                 "slide": {
@@ -5039,26 +5039,26 @@
                     "version": "2.1.3",
                     "bundled": true,
                     "requires": {
-                        "from2": "1.3.0",
-                        "stream-iterate": "1.2.0"
+                        "from2": "^1.3.0",
+                        "stream-iterate": "^1.1.0"
                     },
                     "dependencies": {
                         "from2": {
                             "version": "1.3.0",
                             "bundled": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "1.1.14"
+                                "inherits": "~2.0.1",
+                                "readable-stream": "~1.1.10"
                             },
                             "dependencies": {
                                 "readable-stream": {
                                     "version": "1.1.14",
                                     "bundled": true,
                                     "requires": {
-                                        "core-util-is": "1.0.2",
-                                        "inherits": "2.0.3",
+                                        "core-util-is": "~1.0.0",
+                                        "inherits": "~2.0.1",
                                         "isarray": "0.0.1",
-                                        "string_decoder": "0.10.31"
+                                        "string_decoder": "~0.10.x"
                                     },
                                     "dependencies": {
                                         "core-util-is": {
@@ -5081,8 +5081,8 @@
                             "version": "1.2.0",
                             "bundled": true,
                             "requires": {
-                                "readable-stream": "2.3.4",
-                                "stream-shift": "1.0.0"
+                                "readable-stream": "^2.1.5",
+                                "stream-shift": "^1.0.0"
                             },
                             "dependencies": {
                                 "stream-shift": {
@@ -5097,14 +5097,14 @@
                     "version": "5.2.4",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "^5.1.1"
                     }
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -5117,33 +5117,33 @@
                     "version": "4.3.3",
                     "bundled": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.1",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.3",
+                        "minipass": "^2.2.1",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "yallist": "^3.0.2"
                     },
                     "dependencies": {
                         "fs-minipass": {
                             "version": "1.2.5",
                             "bundled": true,
                             "requires": {
-                                "minipass": "2.2.1"
+                                "minipass": "^2.2.1"
                             }
                         },
                         "minipass": {
                             "version": "2.2.1",
                             "bundled": true,
                             "requires": {
-                                "yallist": "3.0.2"
+                                "yallist": "^3.0.0"
                             }
                         },
                         "minizlib": {
                             "version": "1.1.0",
                             "bundled": true,
                             "requires": {
-                                "minipass": "2.2.1"
+                                "minipass": "^2.2.1"
                             }
                         },
                         "yallist": {
@@ -5168,14 +5168,14 @@
                     "version": "1.1.0",
                     "bundled": true,
                     "requires": {
-                        "unique-slug": "2.0.0"
+                        "unique-slug": "^2.0.0"
                     },
                     "dependencies": {
                         "unique-slug": {
                             "version": "2.0.0",
                             "bundled": true,
                             "requires": {
-                                "imurmurhash": "0.1.4"
+                                "imurmurhash": "^0.1.4"
                             }
                         }
                     }
@@ -5188,35 +5188,35 @@
                     "version": "2.3.0",
                     "bundled": true,
                     "requires": {
-                        "boxen": "1.2.1",
-                        "chalk": "2.1.0",
-                        "configstore": "3.1.1",
-                        "import-lazy": "2.1.0",
-                        "is-installed-globally": "0.1.0",
-                        "is-npm": "1.0.0",
-                        "latest-version": "3.1.0",
-                        "semver-diff": "2.1.0",
-                        "xdg-basedir": "3.0.0"
+                        "boxen": "^1.2.1",
+                        "chalk": "^2.0.1",
+                        "configstore": "^3.0.0",
+                        "import-lazy": "^2.1.0",
+                        "is-installed-globally": "^0.1.0",
+                        "is-npm": "^1.0.0",
+                        "latest-version": "^3.0.0",
+                        "semver-diff": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
                     },
                     "dependencies": {
                         "boxen": {
                             "version": "1.2.1",
                             "bundled": true,
                             "requires": {
-                                "ansi-align": "2.0.0",
-                                "camelcase": "4.1.0",
-                                "chalk": "2.1.0",
-                                "cli-boxes": "1.0.0",
-                                "string-width": "2.1.1",
-                                "term-size": "1.2.0",
-                                "widest-line": "1.0.0"
+                                "ansi-align": "^2.0.0",
+                                "camelcase": "^4.0.0",
+                                "chalk": "^2.0.1",
+                                "cli-boxes": "^1.0.0",
+                                "string-width": "^2.0.0",
+                                "term-size": "^1.2.0",
+                                "widest-line": "^1.0.0"
                             },
                             "dependencies": {
                                 "ansi-align": {
                                     "version": "2.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "string-width": "2.1.1"
+                                        "string-width": "^2.0.0"
                                     }
                                 },
                                 "camelcase": {
@@ -5231,8 +5231,8 @@
                                     "version": "2.1.1",
                                     "bundled": true,
                                     "requires": {
-                                        "is-fullwidth-code-point": "2.0.0",
-                                        "strip-ansi": "4.0.0"
+                                        "is-fullwidth-code-point": "^2.0.0",
+                                        "strip-ansi": "^4.0.0"
                                     },
                                     "dependencies": {
                                         "is-fullwidth-code-point": {
@@ -5245,36 +5245,36 @@
                                     "version": "1.2.0",
                                     "bundled": true,
                                     "requires": {
-                                        "execa": "0.7.0"
+                                        "execa": "^0.7.0"
                                     },
                                     "dependencies": {
                                         "execa": {
                                             "version": "0.7.0",
                                             "bundled": true,
                                             "requires": {
-                                                "cross-spawn": "5.1.0",
-                                                "get-stream": "3.0.0",
-                                                "is-stream": "1.1.0",
-                                                "npm-run-path": "2.0.2",
-                                                "p-finally": "1.0.0",
-                                                "signal-exit": "3.0.2",
-                                                "strip-eof": "1.0.0"
+                                                "cross-spawn": "^5.0.1",
+                                                "get-stream": "^3.0.0",
+                                                "is-stream": "^1.1.0",
+                                                "npm-run-path": "^2.0.0",
+                                                "p-finally": "^1.0.0",
+                                                "signal-exit": "^3.0.0",
+                                                "strip-eof": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "cross-spawn": {
                                                     "version": "5.1.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "lru-cache": "4.1.1",
-                                                        "shebang-command": "1.2.0",
-                                                        "which": "1.3.0"
+                                                        "lru-cache": "^4.0.1",
+                                                        "shebang-command": "^1.2.0",
+                                                        "which": "^1.2.9"
                                                     },
                                                     "dependencies": {
                                                         "shebang-command": {
                                                             "version": "1.2.0",
                                                             "bundled": true,
                                                             "requires": {
-                                                                "shebang-regex": "1.0.0"
+                                                                "shebang-regex": "^1.0.0"
                                                             },
                                                             "dependencies": {
                                                                 "shebang-regex": {
@@ -5297,7 +5297,7 @@
                                                     "version": "2.0.2",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "path-key": "2.0.1"
+                                                        "path-key": "^2.0.0"
                                                     },
                                                     "dependencies": {
                                                         "path-key": {
@@ -5326,16 +5326,16 @@
                                     "version": "1.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "string-width": "1.0.2"
+                                        "string-width": "^1.0.1"
                                     },
                                     "dependencies": {
                                         "string-width": {
                                             "version": "1.0.2",
                                             "bundled": true,
                                             "requires": {
-                                                "code-point-at": "1.1.0",
-                                                "is-fullwidth-code-point": "1.0.0",
-                                                "strip-ansi": "3.0.1"
+                                                "code-point-at": "^1.0.0",
+                                                "is-fullwidth-code-point": "^1.0.0",
+                                                "strip-ansi": "^3.0.0"
                                             },
                                             "dependencies": {
                                                 "code-point-at": {
@@ -5346,7 +5346,7 @@
                                                     "version": "1.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "number-is-nan": "1.0.1"
+                                                        "number-is-nan": "^1.0.0"
                                                     },
                                                     "dependencies": {
                                                         "number-is-nan": {
@@ -5359,7 +5359,7 @@
                                                     "version": "3.0.1",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "ansi-regex": "2.1.1"
+                                                        "ansi-regex": "^2.0.0"
                                                     },
                                                     "dependencies": {
                                                         "ansi-regex": {
@@ -5378,23 +5378,23 @@
                             "version": "2.1.0",
                             "bundled": true,
                             "requires": {
-                                "ansi-styles": "3.2.0",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "4.4.0"
+                                "ansi-styles": "^3.1.0",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^4.0.0"
                             },
                             "dependencies": {
                                 "ansi-styles": {
                                     "version": "3.2.0",
                                     "bundled": true,
                                     "requires": {
-                                        "color-convert": "1.9.0"
+                                        "color-convert": "^1.9.0"
                                     },
                                     "dependencies": {
                                         "color-convert": {
                                             "version": "1.9.0",
                                             "bundled": true,
                                             "requires": {
-                                                "color-name": "1.1.3"
+                                                "color-name": "^1.1.1"
                                             },
                                             "dependencies": {
                                                 "color-name": {
@@ -5413,7 +5413,7 @@
                                     "version": "4.4.0",
                                     "bundled": true,
                                     "requires": {
-                                        "has-flag": "2.0.0"
+                                        "has-flag": "^2.0.0"
                                     },
                                     "dependencies": {
                                         "has-flag": {
@@ -5428,19 +5428,19 @@
                             "version": "3.1.1",
                             "bundled": true,
                             "requires": {
-                                "dot-prop": "4.2.0",
-                                "graceful-fs": "4.1.11",
-                                "make-dir": "1.0.0",
-                                "unique-string": "1.0.0",
-                                "write-file-atomic": "2.1.0",
-                                "xdg-basedir": "3.0.0"
+                                "dot-prop": "^4.1.0",
+                                "graceful-fs": "^4.1.2",
+                                "make-dir": "^1.0.0",
+                                "unique-string": "^1.0.0",
+                                "write-file-atomic": "^2.0.0",
+                                "xdg-basedir": "^3.0.0"
                             },
                             "dependencies": {
                                 "dot-prop": {
                                     "version": "4.2.0",
                                     "bundled": true,
                                     "requires": {
-                                        "is-obj": "1.0.1"
+                                        "is-obj": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "is-obj": {
@@ -5453,7 +5453,7 @@
                                     "version": "1.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "pify": "2.3.0"
+                                        "pify": "^2.3.0"
                                     },
                                     "dependencies": {
                                         "pify": {
@@ -5466,7 +5466,7 @@
                                     "version": "1.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "crypto-random-string": "1.0.0"
+                                        "crypto-random-string": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "crypto-random-string": {
@@ -5485,22 +5485,22 @@
                             "version": "0.1.0",
                             "bundled": true,
                             "requires": {
-                                "global-dirs": "0.1.0",
-                                "is-path-inside": "1.0.0"
+                                "global-dirs": "^0.1.0",
+                                "is-path-inside": "^1.0.0"
                             },
                             "dependencies": {
                                 "global-dirs": {
                                     "version": "0.1.0",
                                     "bundled": true,
                                     "requires": {
-                                        "ini": "1.3.5"
+                                        "ini": "^1.3.4"
                                     }
                                 },
                                 "is-path-inside": {
                                     "version": "1.0.0",
                                     "bundled": true,
                                     "requires": {
-                                        "path-is-inside": "1.0.2"
+                                        "path-is-inside": "^1.0.1"
                                     }
                                 }
                             }
@@ -5513,41 +5513,41 @@
                             "version": "3.1.0",
                             "bundled": true,
                             "requires": {
-                                "package-json": "4.0.1"
+                                "package-json": "^4.0.0"
                             },
                             "dependencies": {
                                 "package-json": {
                                     "version": "4.0.1",
                                     "bundled": true,
                                     "requires": {
-                                        "got": "6.7.1",
-                                        "registry-auth-token": "3.3.1",
-                                        "registry-url": "3.1.0",
-                                        "semver": "5.5.0"
+                                        "got": "^6.7.1",
+                                        "registry-auth-token": "^3.0.1",
+                                        "registry-url": "^3.0.3",
+                                        "semver": "^5.1.0"
                                     },
                                     "dependencies": {
                                         "got": {
                                             "version": "6.7.1",
                                             "bundled": true,
                                             "requires": {
-                                                "create-error-class": "3.0.2",
-                                                "duplexer3": "0.1.4",
-                                                "get-stream": "3.0.0",
-                                                "is-redirect": "1.0.0",
-                                                "is-retry-allowed": "1.1.0",
-                                                "is-stream": "1.1.0",
-                                                "lowercase-keys": "1.0.0",
-                                                "safe-buffer": "5.1.1",
-                                                "timed-out": "4.0.1",
-                                                "unzip-response": "2.0.1",
-                                                "url-parse-lax": "1.0.0"
+                                                "create-error-class": "^3.0.0",
+                                                "duplexer3": "^0.1.4",
+                                                "get-stream": "^3.0.0",
+                                                "is-redirect": "^1.0.0",
+                                                "is-retry-allowed": "^1.0.0",
+                                                "is-stream": "^1.0.0",
+                                                "lowercase-keys": "^1.0.0",
+                                                "safe-buffer": "^5.0.1",
+                                                "timed-out": "^4.0.0",
+                                                "unzip-response": "^2.0.1",
+                                                "url-parse-lax": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "create-error-class": {
                                                     "version": "3.0.2",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "capture-stack-trace": "1.0.0"
+                                                        "capture-stack-trace": "^1.0.0"
                                                     },
                                                     "dependencies": {
                                                         "capture-stack-trace": {
@@ -5592,7 +5592,7 @@
                                                     "version": "1.0.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "prepend-http": "1.0.4"
+                                                        "prepend-http": "^1.0.1"
                                                     },
                                                     "dependencies": {
                                                         "prepend-http": {
@@ -5607,18 +5607,18 @@
                                             "version": "3.3.1",
                                             "bundled": true,
                                             "requires": {
-                                                "rc": "1.2.1",
-                                                "safe-buffer": "5.1.1"
+                                                "rc": "^1.1.6",
+                                                "safe-buffer": "^5.0.1"
                                             },
                                             "dependencies": {
                                                 "rc": {
                                                     "version": "1.2.1",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "deep-extend": "0.4.2",
-                                                        "ini": "1.3.5",
-                                                        "minimist": "1.2.0",
-                                                        "strip-json-comments": "2.0.1"
+                                                        "deep-extend": "~0.4.0",
+                                                        "ini": "~1.3.0",
+                                                        "minimist": "^1.2.0",
+                                                        "strip-json-comments": "~2.0.1"
                                                     },
                                                     "dependencies": {
                                                         "deep-extend": {
@@ -5641,17 +5641,17 @@
                                             "version": "3.1.0",
                                             "bundled": true,
                                             "requires": {
-                                                "rc": "1.2.1"
+                                                "rc": "^1.0.1"
                                             },
                                             "dependencies": {
                                                 "rc": {
                                                     "version": "1.2.1",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "deep-extend": "0.4.2",
-                                                        "ini": "1.3.5",
-                                                        "minimist": "1.2.0",
-                                                        "strip-json-comments": "2.0.1"
+                                                        "deep-extend": "~0.4.0",
+                                                        "ini": "~1.3.0",
+                                                        "minimist": "^1.2.0",
+                                                        "strip-json-comments": "~2.0.1"
                                                     },
                                                     "dependencies": {
                                                         "deep-extend": {
@@ -5678,7 +5678,7 @@
                             "version": "2.1.0",
                             "bundled": true,
                             "requires": {
-                                "semver": "5.5.0"
+                                "semver": "^5.0.3"
                             }
                         },
                         "xdg-basedir": {
@@ -5695,15 +5695,15 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "spdx-correct": "1.0.2",
-                        "spdx-expression-parse": "1.0.4"
+                        "spdx-correct": "~1.0.0",
+                        "spdx-expression-parse": "~1.0.0"
                     },
                     "dependencies": {
                         "spdx-correct": {
                             "version": "1.0.2",
                             "bundled": true,
                             "requires": {
-                                "spdx-license-ids": "1.2.2"
+                                "spdx-license-ids": "^1.0.2"
                             },
                             "dependencies": {
                                 "spdx-license-ids": {
@@ -5722,7 +5722,7 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "builtins": "1.0.3"
+                        "builtins": "^1.0.3"
                     },
                     "dependencies": {
                         "builtins": {
@@ -5735,7 +5735,7 @@
                     "version": "1.3.0",
                     "bundled": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     },
                     "dependencies": {
                         "isexe": {
@@ -5748,15 +5748,15 @@
                     "version": "1.5.2",
                     "bundled": true,
                     "requires": {
-                        "errno": "0.1.7",
-                        "xtend": "4.0.1"
+                        "errno": "^0.1.4",
+                        "xtend": "^4.0.1"
                     },
                     "dependencies": {
                         "errno": {
                             "version": "0.1.7",
                             "bundled": true,
                             "requires": {
-                                "prr": "1.0.1"
+                                "prr": "~1.0.1"
                             },
                             "dependencies": {
                                 "prr": {
@@ -5779,9 +5779,9 @@
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "imurmurhash": "0.1.4",
-                        "slide": "1.1.6"
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "slide": "^1.1.5"
                     }
                 }
             }
@@ -5804,8 +5804,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "once": {
@@ -5814,7 +5814,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "ordered-read-streams": {
@@ -5823,8 +5823,8 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.5"
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
         "parse-glob": {
@@ -5833,10 +5833,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -5851,7 +5851,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -5874,7 +5874,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -5901,7 +5901,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plugin-error": {
@@ -5910,11 +5910,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
         },
         "preserve": {
@@ -5953,7 +5953,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -5962,8 +5962,8 @@
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -5972,7 +5972,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5981,7 +5981,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5992,7 +5992,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -6003,13 +6003,13 @@
             "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             }
         },
         "regex-cache": {
@@ -6018,7 +6018,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "remove-trailing-separator": {
@@ -6051,28 +6051,28 @@
             "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "hawk": "~6.0.2",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "stringstream": "~0.0.5",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6093,7 +6093,7 @@
                     "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "caseless": {
@@ -6108,7 +6108,7 @@
                     "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                     "dev": true,
                     "requires": {
-                        "boom": "5.2.0"
+                        "boom": "5.x.x"
                     },
                     "dependencies": {
                         "boom": {
@@ -6117,7 +6117,7 @@
                             "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                             "dev": true,
                             "requires": {
-                                "hoek": "4.2.1"
+                                "hoek": "4.x.x"
                             }
                         }
                     }
@@ -6128,9 +6128,9 @@
                     "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
                     "dev": true,
                     "requires": {
-                        "asynckit": "0.4.0",
+                        "asynckit": "^0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "2.1.18"
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "har-validator": {
@@ -6139,8 +6139,8 @@
                     "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
                     "dev": true,
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "hawk": {
@@ -6149,10 +6149,10 @@
                     "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
                     "dev": true,
                     "requires": {
-                        "boom": "4.3.1",
-                        "cryptiles": "3.1.2",
-                        "hoek": "4.2.1",
-                        "sntp": "2.1.0"
+                        "boom": "4.x.x",
+                        "cryptiles": "3.x.x",
+                        "hoek": "4.x.x",
+                        "sntp": "2.x.x"
                     }
                 },
                 "hoek": {
@@ -6167,9 +6167,9 @@
                     "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "dev": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.13.1"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "qs": {
@@ -6184,7 +6184,7 @@
                     "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "tunnel-agent": {
@@ -6193,7 +6193,7 @@
                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 }
             }
@@ -6210,7 +6210,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -6237,7 +6237,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "source-map": {
@@ -6252,7 +6252,7 @@
             "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.0"
             }
         },
         "sparkles": {
@@ -6267,7 +6267,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "sshpk": {
@@ -6276,14 +6276,14 @@
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6306,7 +6306,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -6321,7 +6321,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -6336,7 +6336,7 @@
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -6351,7 +6351,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -6360,7 +6360,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -6369,8 +6369,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "supports-color": {
@@ -6385,9 +6385,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "through": {
@@ -6402,8 +6402,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -6412,8 +6412,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -6428,7 +6428,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6437,7 +6437,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -6454,7 +6454,7 @@
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tunnel-agent": {
@@ -6482,8 +6482,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "url-parse": {
@@ -6492,8 +6492,8 @@
             "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
             "dev": true,
             "requires": {
-                "querystringify": "1.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "~1.0.0",
+                "requires-port": "~1.0.0"
             }
         },
         "util-deprecate": {
@@ -6520,9 +6520,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6539,8 +6539,8 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
             }
         },
         "vinyl-fs": {
@@ -6549,23 +6549,23 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.5",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -6586,8 +6586,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -6599,8 +6599,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             }
         },
         "vscode": {
@@ -6609,20 +6609,20 @@
             "integrity": "sha512-WpHxNfZoxT/JjJbfNNTmXHV9up03yjo3I+jZcYvDvukvYgHtNsvAC98RLz18qmoLwJTncEKrLoxwd4A+VHMmlA==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.85.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.3",
-                "url-parse": "1.2.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src": "^0.4.3",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.6",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {
                 "commander": {
@@ -6682,7 +6682,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -6705,8 +6705,8 @@
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yazl": {
@@ -6715,7 +6715,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }


### PR DESCRIPTION
## Code Formatting

Support "Format Document" if `clang-format` is in path, including custom `style` options.

By default, `clang-format`'s standard coding style will be used for formatting. To define a custom style or use a supported preset add `"clang-format.style"` in VSCode Settings (`settings.json`)

### Example usage:
`"clang-format.style": "google"`

This is the equivalent of executing `clang-format -style=google` from the shell.

For further formatting options refer to the [official `clang-format` documentation](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)