### PR TITLE
Configuration syncing, compile all fix, compile on save, readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@ Protobuf 3 support for Visual Studio Code
 
 https://github.com/zxh0/vscode-proto3
 
+### VSCode Commands
+
+_By default **ctrl-shift-p** opens the command prompt._
+
+| Command | Description |
+|---------|-------------|
+| `proto3: Compile All Protos` | Compiles all workspace protos using [configurations](#extension-settings) defined with `protoc.options`. |
+| `proto3: Compile This Proto` | Compiles the active proto using [configurations](#extension-settings) defined with `protoc.options`. |
+
+
 ## Features
 
-- proto3 support.
 - syntax highlighting.
 - syntax validation.
 - code snippets.
@@ -14,6 +23,7 @@ https://github.com/zxh0/vscode-proto3
 - code formatting.
 - brace matching.
 - line and block commenting.
+- compilation.
 
 ![gif1](images/gif1.gif)
 
@@ -26,30 +36,47 @@ The grammar is written in tmLanguage JSON format.
 The validation is triggered when you save the proto file. You need protoc 
 compiler to enable syntax validation. You also need a settings.json file 
 to tell the extension the full path of protoc if it is not in `path`. 
-Bellow is the settings.json file comes from 
-[example/.vscode](https://github.com/zxh0/vscode-proto3/tree/master/example/.vscode) folder:
+
+### Extension Settings
+
+Below is an example settings.json file which comes from 
+[example/.vscode](https://github.com/zxh0/vscode-proto3/tree/master/example/.vscode):
 ```json
 {
     "protoc": {
         "path": "/path/to/protoc",
+        "compile_on_save": false,
         "options": [
             "--proto_path=protos/v3",
             "--proto_path=protos/v2",
             "--proto_path=${workspaceRoot}/proto",
-            "--proto_path=${env.GOPATH}/src"
+            "--proto_path=${env.GOPATH}/src",
             "--java_out=gen/java"
         ]
     }
 }
 ```
 
-Variables
+#### Fields
 
-Variable      | Description
-------------- | ------------
-config.*      | Refer settings items in ``Preferences``.
-env.*         | Refer environment variable.
-workspaceRoot | Returns current workspace root path.
+The possible fields under the `protoc` extension settings which can be defined in a `settings.json` file.
+
+| Field           | Type     | Default          | Description                                                                    |
+| --------------- | -------- | ---------------- | ------------------------------------------------------------------------------ |
+| path            | string   | _protoc in PATH_ | Path to protoc. Defaults to protoc in PATH if omitted.                         |
+| compile_on_save | boolean  | false            | On `.proto` file save, compiles to `--*_out` location within `options`         |
+| options         | string[] | []               | protoc compiler arguments/flags, required for proto validation and compilation |
+
+
+#### In-Line Variables
+
+These variables can be used to inject variables strings within the `protoc` extension configurations. See above for examples.
+
+| Variable      | Description                              |
+| ------------- | ---------------------------------------- |
+| config.*      | Refer settings items in ``Preferences``. |
+| env.*         | Refer environment variable.              |
+| workspaceRoot | Returns current workspace root path.     |
 
 ### Code Completion
 
@@ -57,49 +84,49 @@ A very simple parser is written to support code completion.
 
 ### Code Snippets
 
-prefix| body
------ | -----
-sp2   | `syntax = "proto2";`
-sp3   | `syntax = "proto3";`
-pkg   | `package package.name;`
-imp   | `import "path/to/other/protos.proto";`
-ojp   | `option java_package = "java.package.name";`
-ojoc  | `option java_outer_classname = "ClassName";`
-o4s   | `option optimize_for = SPEED;`
-o4cs  | `option optimize_for = CODE_SIZE;`
-o4lr  | `option optimize_for = LITE_RUNTIME;`
-odep  | `option deprecated = true;`
-oaa   | `option allow_alias = true;`
-msg   | `message MessageName {}`
-fbo   | `bool field_name = tag;`
-fi32  | `int32 field_name = tag;`
-fi64  | `int64 field_name = tag;`
-fu32  | `uint32 field_name = tag;`
-fu64  | `uint64 field_name = tag;`
-fs32  | `sint32 field_name = tag;`
-fs64  | `sint64 field_name = tag;`
-ff32  | `fixed32 field_name = tag;`
-ff64  | `fixed64 field_name = tag;`
-fsf32 | `sfixed32 field_name = tag;`
-fsf64 | `sfixed64 field_name = tag;`
-ffl   | `float field_name = tag;`
-fdo   | `double field_name = tag;`
-fst   | `string field_name = tag;`
-fby   | `bytes field_name = tag;`
-fm    | `map<key, val> field_name = tag;`
-foo   | `oneof name {}`
-en    | `enum EnumName {}`
-sv    | `service ServiceName {}`
-rpc   | `rpc MethodName (Request) returns (Response);`
+| prefix | body                                           |
+| ------ | ---------------------------------------------- |
+| sp2    | `syntax = "proto2";`                           |
+| sp3    | `syntax = "proto3";`                           |
+| pkg    | `package package.name;`                        |
+| imp    | `import "path/to/other/protos.proto";`         |
+| ojp    | `option java_package = "java.package.name";`   |
+| ojoc   | `option java_outer_classname = "ClassName";`   |
+| o4s    | `option optimize_for = SPEED;`                 |
+| o4cs   | `option optimize_for = CODE_SIZE;`             |
+| o4lr   | `option optimize_for = LITE_RUNTIME;`          |
+| odep   | `option deprecated = true;`                    |
+| oaa    | `option allow_alias = true;`                   |
+| msg    | `message MessageName {}`                       |
+| fbo    | `bool field_name = tag;`                       |
+| fi32   | `int32 field_name = tag;`                      |
+| fi64   | `int64 field_name = tag;`                      |
+| fu32   | `uint32 field_name = tag;`                     |
+| fu64   | `uint64 field_name = tag;`                     |
+| fs32   | `sint32 field_name = tag;`                     |
+| fs64   | `sint64 field_name = tag;`                     |
+| ff32   | `fixed32 field_name = tag;`                    |
+| ff64   | `fixed64 field_name = tag;`                    |
+| fsf32  | `sfixed32 field_name = tag;`                   |
+| fsf64  | `sfixed64 field_name = tag;`                   |
+| ffl    | `float field_name = tag;`                      |
+| fdo    | `double field_name = tag;`                     |
+| fst    | `string field_name = tag;`                     |
+| fby    | `bytes field_name = tag;`                      |
+| fm     | `map<key, val> field_name = tag;`              |
+| foo    | `oneof name {}`                                |
+| en     | `enum EnumName {}`                             |
+| sv     | `service ServiceName {}`                       |
+| rpc    | `rpc MethodName (Request) returns (Response);` |
 
 ### Google API Design Guide
 
 The following snippets are based on
 [Google API Design Guide](https://cloud.google.com/apis/design/).
 
-prefix | reference
------- | -----
-svgapi | [Standard Methods](https://cloud.google.com/apis/design/standard_methods)
+| prefix | reference                                                                 |
+| ------ | ------------------------------------------------------------------------- |
+| svgapi | [Standard Methods](https://cloud.google.com/apis/design/standard_methods) |
 
 ## Code Formatting
 

--- a/src/proto3Compiler.ts
+++ b/src/proto3Compiler.ts
@@ -1,20 +1,18 @@
 'use strict';
 
 import vscode = require('vscode');
-import fs = require('fs');
 import path = require('path');
 import cp = require('child_process');
-import os = require('os');
+
+import { Proto3Configuration } from './proto3Configuration';
 
 export class Proto3Compiler {
  
-    private _settings: vscode.WorkspaceConfiguration;
-    private _configResolver: ConfigurationResolver;
+    private _config: Proto3Configuration;
     private _isProtocInPath: boolean;
 
     constructor() {
-        this._settings = vscode.workspace.getConfiguration("protoc");
-        this._configResolver = new ConfigurationResolver();
+        this._config = Proto3Configuration.Instance();
         try {
             cp.execFileSync("protoc", ["-h"]);
             this._isProtocInPath = true;
@@ -24,12 +22,13 @@ export class Proto3Compiler {
     }
 
     public compileAllProtos() {
-        let args = this.getProtocOptions()
-            .concat(this.getProtos());
-
-        this.runProtoc(args, undefined, (stdout, stderr) => {
-            vscode.window.showErrorMessage(stderr);
-        });
+        let args = this._config.getProtocOptions();
+        // Compile in batch produces errors. Must be 1 by 1.
+        this._config.getAllProtoPaths().forEach(proto => {
+            this.runProtoc(args.concat(proto), undefined, (stdout, stderr) => {
+                vscode.window.showErrorMessage(stderr);
+            });
+        })
     }
 
     public compileActiveProto() {
@@ -37,7 +36,7 @@ export class Proto3Compiler {
         if (editor && editor.document.languageId == 'proto3') {
             let fileName = editor.document.fileName;
             let proto = path.relative(vscode.workspace.rootPath, fileName);
-            let args = this.getProtocOptions().concat(proto);
+            let args = this._config.getProtocOptions().concat(proto);
 
             this.runProtoc(args, undefined, (stdout, stderr) => {
                 vscode.window.showErrorMessage(stderr);
@@ -48,8 +47,8 @@ export class Proto3Compiler {
     public compileProtoToTmp(fileName: string, callback?: (stderr: string) =>void) {
         let proto = path.relative(vscode.workspace.rootPath, fileName);
 
-        let args = this.getProtoPathOptions()
-                .concat(this.getTmpJavaOutOption(), proto);
+        let args = this._config.getProtoPathOptions()
+                .concat(this._config.getTmpJavaOutOption(), proto);
 
         this.runProtoc(args, undefined, (stdout, stderr) => {
             if (callback) {
@@ -59,7 +58,7 @@ export class Proto3Compiler {
     }
 
     private runProtoc(args: string[], opts?: cp.ExecFileOptions, callback?: (stdout: string, stderr: string) =>void) {
-        let protocPath = this.getProtocPath()
+        let protocPath = this._config.getProtocPath(this._isProtocInPath)
         if (protocPath == "?") {
             return // protoc is not configured
         }
@@ -81,141 +80,4 @@ export class Proto3Compiler {
             }
         });       
     }
-
-    private getProtocPath(): string {
-        let protoc = this._isProtocInPath ? 'protoc' : '?';
-        return this._configResolver.resolve(
-            this._settings.get<string>('path', protoc));
-    }
-
-    private getProtocOptions(): string[] {
-        return this._configResolver.resolve(
-            this._settings.get<string[]>('options', []));
-    }
-
-    private getProtoPathOptions(): string[] {
-        return this.getProtocOptions()
-            .filter(opt => opt.startsWith('--proto_path') || opt.startsWith('-I'));
-    }
-
-    private getProtos(): string[] {
-        if (this._settings.has('options')) {
-            return this.getProtocOptions();
-        }
-        return new InputCollector().collectInputs(vscode.workspace.rootPath);
-    }
-
-    private getTmpJavaOutOption(): string {
-        return '--java_out=' + os.tmpdir();
-    }
-}
-
-class InputCollector {
-
-    inputs: string[] = [];
-
-    collectInputs(dir: string): string[] {
-        let kids = fs.readdirSync(dir);
-        if (kids.some(kid => kid.endsWith(".proto"))) {
-            let relDir = path.relative(vscode.workspace.rootPath, dir);
-            let input = path.join(relDir, "*.proto");
-            this.inputs = this.inputs.concat(input);
-        }
-        kids.map(kid => path.join(dir, kid))
-            .filter(kid => fs.statSync(kid).isDirectory())
-            .forEach(subDir => this.collectInputs(subDir));
-        return this.inputs;
-    }
-
-}
-
-// Workaround to substitute variable keywords in the configuration value until
-// workbench/services/configurationResolver is available on Extention API.
-//
-// 
-// Some codes are copied from:
-// src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
-class ConfigurationResolver {
-
-    constructor(){
-        Object.keys(process.env).forEach(key => {
-			this[`env.${key}`] = process.env[key];
-		});
-    }
-
-	public resolve(value: string): string;
-	public resolve(value: string[]): string[];
-    public resolve(value: any): any {
-        if (typeof value === 'string') {
-            return this.resolveString(value);
-        } else if (this.isArray(value)) {
-            return this.resolveArray(value);
-        }
-        return value;
-    }
-
-    private isArray(array: any): array is any[] {
-        if (Array.isArray) {
-            return Array.isArray(array);
-        }
-
-        if (array && typeof (array.length) === 'number' && array.constructor === Array) {
-            return true;
-        }
-
-        return false;
-    }
-	
-    private resolveArray(value: string[]): string[] {
-		return value.map(s => this.resolveString(s));
-	}
-
-    private resolveString(value: string): string {
-		let regexp = /\$\{(.*?)\}/g;
-		const originalValue = value;
-		const resolvedString = value.replace(regexp, (match: string, name: string) => {
-			let newValue = (<any>this)[name];
-			if (typeof newValue === 'string') {
-				return newValue;
-			} else {
-				return match && match.indexOf('env.') > 0 ? '' : match;
-			}
-		});
-
-		return this.resolveConfigVariable(resolvedString, originalValue);
-	}
-    
-    private resolveConfigVariable(value: string, originalValue: string): string {
-		let regexp = /\$\{config\.(.+?)\}/g;
-		return value.replace(regexp, (match: string, name: string) => {
-			let config = vscode.workspace.getConfiguration();
-			let newValue: any;
-			try {
-				const keys: string[] = name.split('.');
-				if (!keys || keys.length <= 0) {
-					return '';
-				}
-				while (keys.length > 1) {
-					const key = keys.shift();
-					if (!config || !config.hasOwnProperty(key)) {
-						return '';
-					}
-					config = config[key];
-				}
-				newValue = config && config.hasOwnProperty(keys[0]) ? config[keys[0]] : '';
-			} catch (e) {
-				return '';
-			}
-			if (typeof newValue === 'string') {
-				// Prevent infinite recursion and also support nested references (or tokens)
-				return newValue === originalValue ? '' : this.resolveString(newValue);
-			} else {
-				return this.resolve(newValue) + '';
-			}
-		});
-	}
-
-    private get workspaceRoot(): string {
-		return vscode.workspace.rootPath;
-	}
 }

--- a/src/proto3Configuration.ts
+++ b/src/proto3Configuration.ts
@@ -1,0 +1,177 @@
+'use strict';
+
+import vscode = require('vscode');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+export class Proto3Configuration {
+
+    private readonly _configSection: string = 'protoc';
+    private static _instance: Proto3Configuration = null;
+    private _config: vscode.WorkspaceConfiguration;
+    private _configResolver: ConfigurationResolver;
+
+    public static Instance(): Proto3Configuration {
+        if (Proto3Configuration._instance == null) {
+            this._instance = new Proto3Configuration();
+        }
+        return Proto3Configuration._instance;
+    }
+
+    private constructor() {
+        this._config = vscode.workspace.getConfiguration(this._configSection);
+        vscode.workspace.onDidChangeConfiguration(event => {
+            this._config = vscode.workspace.getConfiguration(this._configSection);
+        });
+        this._configResolver = new ConfigurationResolver();
+    }
+
+    public getProtocPath(protocInPath: boolean): string {
+        let protoc = protocInPath ? 'protoc' : '?';
+        return this._configResolver.resolve(
+            this._config.get<string>('path', protoc));
+    }
+
+    public getProtocArgs(): string[] {
+        return this._configResolver.resolve(
+            this._config.get<string[]>('options', []));
+    }
+
+    public getProtocArgFiles(): string[] {
+        return this.getProtocArgs().filter(arg => !arg.startsWith('-'));
+    }
+
+    public getProtocOptions(): string[] {
+        return this.getProtocArgs().filter(arg => arg.startsWith('-'));
+    }
+
+    public getProtoPathOptions(): string[] {
+        return this.getProtocOptions()
+            .filter(opt => opt.startsWith('--proto_path') || opt.startsWith('-I'));
+    }
+
+    public getAllProtoPaths(): string[] {
+        return this.getProtocArgFiles().concat(ProtoFinder.fromDir(vscode.workspace.rootPath));
+    }
+
+    public getTmpJavaOutOption(): string {
+        return '--java_out=' + os.tmpdir();
+    }
+
+    public compileOnSave(): boolean {
+        return this._config.get<boolean>('compile_on_save', false);
+    }
+
+}
+
+class ProtoFinder {
+    static fromDir(root: string): string[] {
+        let search = function(dir: string): string[] {
+            let files = fs.readdirSync(dir);
+            
+            let protos = files.filter(file => file.endsWith('.proto'))
+                          .map(file => path.join(path.relative(root, dir), file));
+
+            files.map(file => path.join(dir, file))
+                .filter(file => fs.statSync(file).isDirectory())
+                .forEach(subDir => {
+                    protos = protos.concat(search(subDir))
+                });
+
+            return protos;
+        }
+        return search(root);
+    }
+}
+
+// Workaround to substitute variable keywords in the configuration value until
+// workbench/services/configurationResolver is available on Extention API.
+//
+// 
+// Some codes are copied from:
+// src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
+class ConfigurationResolver {
+
+    constructor(){
+        Object.keys(process.env).forEach(key => {
+			this[`env.${key}`] = process.env[key];
+		});
+    }
+
+	public resolve(value: string): string;
+	public resolve(value: string[]): string[];
+    public resolve(value: any): any {
+        if (typeof value === 'string') {
+            return this.resolveString(value);
+        } else if (this.isArray(value)) {
+            return this.resolveArray(value);
+        }
+        return value;
+    }
+
+    private isArray(array: any): array is any[] {
+        if (Array.isArray) {
+            return Array.isArray(array);
+        }
+
+        if (array && typeof (array.length) === 'number' && array.constructor === Array) {
+            return true;
+        }
+
+        return false;
+    }
+	
+    private resolveArray(value: string[]): string[] {
+		return value.map(s => this.resolveString(s));
+	}
+
+    private resolveString(value: string): string {
+		let regexp = /\$\{(.*?)\}/g;
+		const originalValue = value;
+		const resolvedString = value.replace(regexp, (match: string, name: string) => {
+			let newValue = (<any>this)[name];
+			if (typeof newValue === 'string') {
+				return newValue;
+			} else {
+				return match && match.indexOf('env.') > 0 ? '' : match;
+			}
+		});
+
+		return this.resolveConfigVariable(resolvedString, originalValue);
+	}
+    
+    private resolveConfigVariable(value: string, originalValue: string): string {
+		let regexp = /\$\{config\.(.+?)\}/g;
+		return value.replace(regexp, (match: string, name: string) => {
+			let config = vscode.workspace.getConfiguration();
+			let newValue: any;
+			try {
+				const keys: string[] = name.split('.');
+				if (!keys || keys.length <= 0) {
+					return '';
+				}
+				while (keys.length > 1) {
+					const key = keys.shift();
+					if (!config || !config.hasOwnProperty(key)) {
+						return '';
+					}
+					config = config[key];
+				}
+				newValue = config && config.hasOwnProperty(keys[0]) ? config[keys[0]] : '';
+			} catch (e) {
+				return '';
+			}
+			if (typeof newValue === 'string') {
+				// Prevent infinite recursion and also support nested references (or tokens)
+				return newValue === originalValue ? '' : this.resolveString(newValue);
+			} else {
+				return this.resolve(newValue) + '';
+			}
+		});
+	}
+
+    private get workspaceRoot(): string {
+		return vscode.workspace.rootPath;
+	}
+}

--- a/src/proto3Main.ts
+++ b/src/proto3Main.ts
@@ -7,6 +7,7 @@ import { Proto3LanguageDiagnosticProvider } from './proto3Diagnostic';
 import { Proto3Compiler } from './proto3Compiler';
 import { PROTO3_MODE } from './proto3Mode';
 import { Proto3DefinitionProvider } from './proto3Definition';
+import { Proto3Configuration } from './proto3Configuration';
 
 function getClangFormatStyle(document): string | null {
     let ret = vscode.workspace.getConfiguration('clang-format').get<string>('style');
@@ -29,6 +30,9 @@ export function activate(ctx: vscode.ExtensionContext): void {
     vscode.workspace.onDidSaveTextDocument(event => {
         if (event.languageId == 'proto3') {
             diagnosticProvider.createDiagnostics(event);
+            if (Proto3Configuration.Instance().compileOnSave()) {
+                compiler.compileActiveProto();
+            }
         }
     });
 
@@ -39,7 +43,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
     ctx.subscriptions.push(vscode.commands.registerCommand('proto3.compile.all', () => {
         compiler.compileAllProtos();
     }));
-
 
     //console.log('Congratulations, your extension "vscode-pb3" is now active!');
 


### PR DESCRIPTION
Fixed and improved various areas related to compilation. 

## Configuration Syncing.

- Moved workspace configuration settings into their own file `proto3Configuration.ts`. This class exposes all the relevant helpers to the fields within a `protoc` settings.
- Added event listener for configuration changes to update local config variable.

## Compile All Fix

- Fixed the command `proto3: Compile All Protos` to work on Windows machine running protoc 3.5+.  This version of protoc (the one I happen to be using) does not support wildcard proto paths e.g. `path/to/*.proto` returns an error. 
- The compile all command now explicitly enumerates all protos to compile.

## Added `compile_on_save` 

- Enabling the `compile_on_save` configuration will compile the active working proto whenever the document is saved.

## Updated README.md

- Added documentation on how to run the compilation commands.
- Improved documentation on `protoc` settings.