### PR TITLE
Fix formatter

### DIFF
--- a/src/proto3Main.ts
+++ b/src/proto3Main.ts
@@ -86,26 +86,23 @@ export function activate(ctx: vscode.ExtensionContext): void {
     });
 
     vscode.languages.registerDocumentFormattingEditProvider('proto3', {
-        provideDocumentFormattingEdits(document: vscode.TextDocument): Thenable<vscode.TextEdit[]> {
-            return document.save().then(x => {
+        provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
+            const style = getClangFormatStyle(document)
+            let args = [];
+            if (style) args.push(`-style=${style}`);
+            args.push(document.fileName);
 
-                const style = getClangFormatStyle(document)
-                let args = [];
-                if (style) args.push(`-style=${style}`);
-                args.push(document.fileName);
-
-                try {
-                    var output = cp.execFileSync("clang-format", args);
-                    if (output) {
-                        let start = new vscode.Position(0, 0)
-                        let end = new vscode.Position(document.lineCount, 0)
-                        let range = new vscode.Range(start, end);
-                        return [vscode.TextEdit.replace(range, output.toString())];
-                    }
-                } catch (e) {
-                    vscode.window.showErrorMessage(e.message);
+            try {
+                var output = cp.execFileSync("clang-format", args);
+                if (output) {
+                    let start = new vscode.Position(0, 0)
+                    let end = new vscode.Position(document.lineCount, 0)
+                    let range = new vscode.Range(start, end);
+                    return [vscode.TextEdit.replace(range, output.toString())];
                 }
-            })
+            } catch (e) {
+                vscode.window.showErrorMessage(e.message);
+            }
         }
     });
 


### PR DESCRIPTION
VSCode [changed your behaviour](https://code.visualstudio.com/updates/v1_42#_handling-slow-save-operations) to handling slow save operations. Because this, the issue #72 its happening.

This PR just remove the statement `return document.save().then(x => {` to make the extension work again.

Closes #72 