### PR TITLE
doc(clang-format): add documentation on multiple formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ By default, `clang-format`'s standard coding style will be used for formatting. 
 
 This is the equivalent of executing `clang-format -style=google` from the shell.
 
+With multiple formatting options
+
+`"clang-format.style": "{ IndentWidth: 4, BasedOnStyle: google, AlignConsecutiveAssignments: true }"`
+
 For further formatting options refer to the [official `clang-format` documentation](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)
 
 ## Known Issues


### PR DESCRIPTION
Following the little issue I had https://github.com/zxh0/vscode-proto3/issues/79, I want to add a small hint for those struggling a bit with that part