### PR TITLE
Add configuration option for compile all action

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ Below is an example settings.json file which comes from
 
 The possible fields under the `protoc` extension settings which can be defined in a `settings.json` file.
 
-| Field           | Type     | Default          | Description                                                                    |
-| --------------- | -------- | ---------------- | ------------------------------------------------------------------------------ |
-| path            | string   | _protoc in PATH_ | Path to protoc. Defaults to protoc in PATH if omitted.                         |
-| compile_on_save | boolean  | false            | On `.proto` file save, compiles to `--*_out` location within `options`         |
-| options         | string[] | []               | protoc compiler arguments/flags, required for proto validation and compilation |
+| Field            | Type     | Default          | Description                                                                    |
+| ---------------- | -------- | ---------------- | ------------------------------------------------------------------------------ |
+| path             | string   | _protoc in PATH_ | Path to protoc. Defaults to protoc in PATH if omitted.                         |
+| compile_on_save  | boolean  | false            | On `.proto` file save, compiles to `--*_out` location within `options`         |
+| compile_all_path | string   | Workspace Root   | Search Path for `Compile All Protos` action. Defaults to the Workspace Root    |
+| options          | string[] | []               | protoc compiler arguments/flags, required for proto validation and compilation |
 
 
 #### In-Line Variables

--- a/src/proto3Configuration.ts
+++ b/src/proto3Configuration.ts
@@ -33,6 +33,11 @@ export class Proto3Configuration {
             this._config.get<string>('path', protoc));
     }
 
+    public getProtoSourcePath(): string {
+        return this._configResolver.resolve(
+            this._config.get<string>('compile_all_path', vscode.workspace.rootPath));
+    }
+
     public getProtocArgs(): string[] {
         return this._configResolver.resolve(
             this._config.get<string[]>('options', []));
@@ -52,7 +57,7 @@ export class Proto3Configuration {
     }
 
     public getAllProtoPaths(): string[] {
-        return this.getProtocArgFiles().concat(ProtoFinder.fromDir(vscode.workspace.rootPath));
+        return this.getProtocArgFiles().concat(ProtoFinder.fromDir(this.getProtoSourcePath()));
     }
 
     public getTmpJavaOutOption(): string {


### PR DESCRIPTION
Having a few unrelated .proto files in my project directory that came with a virtual environment setup, i needed a way to specify a search path for the "compile all" command. Results as seen in this pull request (i.e., a new protoc extension setting has been added).

Example: `"compile_all_path": "${workspaceRoot}/protos"`