### PR TITLE
Add assume filename flag to clang-format arguments

### DIFF
--- a/src/proto3Main.ts
+++ b/src/proto3Main.ts
@@ -79,20 +79,21 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
     vscode.languages.registerDocumentFormattingEditProvider('proto3', {
         provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
-
+            let args = [];
             let opts = { input: document.getText() };
 
             // In order for clang-format to find the correct formatting file we need to have cwd set appropriately
-            switch(document.uri.scheme) {
+            switch (document.uri.scheme) {
                 case "untitled": // File has not yet been saved to disk use workspace path
                     opts['cwd'] = vscode.workspace.rootPath;
+                    args.push(`--assume-filename=untitled.proto`);
                     break;
                 case "file": // File is on disk use it's directory
                     opts['cwd'] = path.dirname(document.uri.fsPath);
+                    args.push(`--assume-filename=${document.uri.fsPath}`);
                     break;
             }
 
-            let args = [];
             let style = vscode.workspace.getConfiguration('clang-format').get<string>('style');
             style = style && style.trim();
             if (style) args.push(`-style=${style}`);


### PR DESCRIPTION
When using stdin as the input source for clang-format, it takes an
--assume-filename argument to determine which language to choose for
formatting. Without this flag, clang-format may assume that the input
text is cpp code and incorrectly apply formatting rules.