### PR TITLE
Don't leak generated Java files

### DIFF
--- a/src/proto3Compiler.ts
+++ b/src/proto3Compiler.ts
@@ -7,7 +7,7 @@ import cp = require('child_process');
 import { Proto3Configuration } from './proto3Configuration';
 
 export class Proto3Compiler {
- 
+
     private _config: Proto3Configuration;
     private _isProtocInPath: boolean;
 
@@ -46,8 +46,7 @@ export class Proto3Compiler {
     public compileProtoToTmp(fileName: string, callback?: (stderr: string) =>void) {
         let proto = path.relative(vscode.workspace.rootPath, fileName);
 
-        let args = this._config.getProtoPathOptions()
-                .concat(this._config.getTmpJavaOutOption(), proto);
+        let args = this._config.getProtoPathOptions().concat(proto);
 
         this.runProtoc(args, undefined, (stdout, stderr) => {
             if (callback) {
@@ -61,7 +60,7 @@ export class Proto3Compiler {
         if (protocPath == "?") {
             return // protoc is not configured
         }
-        
+
         if( !opts ) {
             opts = {};
         }
@@ -77,6 +76,6 @@ export class Proto3Compiler {
             if (callback) {
                 callback(stdout, stderr);
             }
-        });       
+        });
     }
 }

--- a/src/proto3Configuration.ts
+++ b/src/proto3Configuration.ts
@@ -56,10 +56,6 @@ export class Proto3Configuration {
         return this.getProtocArgFiles().concat(ProtoFinder.fromDir(this.getProtoSourcePath()));
     }
 
-    public getTmpJavaOutOption(): string {
-        return '--java_out=' + os.tmpdir();
-    }
-
     public compileOnSave(): boolean {
         return this._config.get<boolean>('compile_on_save', false);
     }
@@ -70,7 +66,7 @@ class ProtoFinder {
     static fromDir(root: string): string[] {
         let search = function(dir: string): string[] {
             let files = fs.readdirSync(dir);
-            
+
             let protos = files.filter(file => file.endsWith('.proto'))
                           .map(file => path.join(path.relative(root, dir), file));
 
@@ -89,7 +85,7 @@ class ProtoFinder {
 // Workaround to substitute variable keywords in the configuration value until
 // workbench/services/configurationResolver is available on Extention API.
 //
-// 
+//
 // Some codes are copied from:
 // src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
 class ConfigurationResolver {
@@ -122,7 +118,7 @@ class ConfigurationResolver {
 
         return false;
     }
-	
+
     private resolveArray(value: string[]): string[] {
 		return value.map(s => this.resolveString(s));
 	}
@@ -141,7 +137,7 @@ class ConfigurationResolver {
 
 		return this.resolveConfigVariable(resolvedString, originalValue);
 	}
-    
+
     private resolveConfigVariable(value: string, originalValue: string): string {
 		let regexp = /\$\{config\.(.+?)\}/g;
 		return value.replace(regexp, (match: string, name: string) => {


### PR DESCRIPTION
When the --java_out flag was set on protoc here, I would get generated Java files in my workspace whenever I saved a .proto file.

Also clean up trailing whitespace in these files.