### PR TITLE
fix issue #101 and #102

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The possible fields under the `protoc` extension settings which can be defined i
 | path             | string   | _protoc in PATH_ | Path to protoc. Defaults to protoc in PATH if omitted.                         |
 | compile_on_save  | boolean  | false            | On `.proto` file save, compiles to `--*_out` location within `options`         |
 | compile_all_path | string   | Workspace Root   | Search Path for `Compile All Protos` action. Defaults to the Workspace Root    |
+| use_absolute_path| boolean  | false            | Set `true` for `compile_all_path` search files using absolute path             |
 | options          | string[] | []               | protoc compiler arguments/flags, required for proto validation and compilation |
 
 

--- a/src/proto3Configuration.ts
+++ b/src/proto3Configuration.ts
@@ -72,7 +72,7 @@ class ProtoFinder {
             let files = fs.readdirSync(dir);
 
             let protos = files.filter(file => file.endsWith('.proto'))
-                          .map(file => path.join(path.relative(root, dir), file));
+                          .map(file => path.posix.join(path.relative(root, dir), file));
 
             files.map(file => path.join(dir, file))
                 .filter(file => fs.statSync(file).isDirectory())

--- a/src/proto3Configuration.ts
+++ b/src/proto3Configuration.ts
@@ -53,7 +53,9 @@ export class Proto3Configuration {
     }
 
     public getAllProtoPaths(): string[] {
-        return this.getProtocArgFiles().concat(ProtoFinder.fromDir(this.getProtoSourcePath()));
+        return this.useAbsolutePath() ?
+            ProtoFinder.fromDirAbsolute(this.getProtoSourcePath()) :
+            this.getProtocArgFiles().concat(ProtoFinder.fromDir(this.getProtoSourcePath()));
     }
 
     public getTmpJavaOutOption(): string {
@@ -64,6 +66,9 @@ export class Proto3Configuration {
         return this._config.get<boolean>('compile_on_save', false);
     }
 
+    public useAbsolutePath(): boolean {
+        return this._config.get<boolean>('use_absolute_path', false);
+    }
 }
 
 class ProtoFinder {
@@ -72,7 +77,7 @@ class ProtoFinder {
             let files = fs.readdirSync(dir);
 
             let protos = files.filter(file => file.endsWith('.proto'))
-                          .map(file => path.posix.join(path.relative(root, dir), file));
+                          .map(file => path.join(path.relative(root, dir), file));
 
             files.map(file => path.join(dir, file))
                 .filter(file => fs.statSync(file).isDirectory())
@@ -83,6 +88,20 @@ class ProtoFinder {
             return protos;
         }
         return search(root);
+    }
+
+    static fromDirAbsolute(root: string): string[] {
+        let files : string[] = [];
+        const getFilesRecursively = (directory) => {
+            const filesInDirectory = fs.readdirSync(directory);
+            for (const file of filesInDirectory) {
+                const absolute = path.join(directory, file);
+                if (fs.statSync(absolute).isDirectory()) getFilesRecursively(absolute);
+                else files.push(absolute);
+            }
+        };
+        getFilesRecursively(root);
+        return files;
     }
 }
 


### PR DESCRIPTION
> File does not reside within any path specified using --proto_path (or -I). You must specify a --proto_path which encompasses this > file. Note that the proto_path must be an exact prefix of the .proto file names -- protoc is too dumb to figure out when two paths > (e.g. absolute and relative) are equivalent (it's harder than you think).

Using 'proto3: Compile All Protos' to searching for subdirectory files recursively always returns an error. Using absolute path could fix this problem
