### PR TITLE
refactor code-completion

### DIFF
--- a/src/proto3Suggest.ts
+++ b/src/proto3Suggest.ts
@@ -11,6 +11,7 @@ let kwImport = createCompletionKeyword("import");
 let kwMessage = createCompletionKeyword("message");
 let kwEnum = createCompletionKeyword("enum");
 let kwReserved = createCompletionKeyword("reserved");
+let kwRpc = createCompletionKeyword("rpc");
 
 let fileOptions = [
   createCompletionOption(
@@ -417,6 +418,14 @@ export class Proto3CompletionItemProvider implements vscode.CompletionItemProvid
       }
 
       switch (scope.name) {
+        case "service":
+          if (textBeforeCursor.match(/^\s*option\s+\(?\w*$/)) {
+            suggestions.push(...serviceOptions);
+          } else {
+            suggestions.push(kwRpc);
+            suggestions.push(kwOption);
+          }
+          break;
         case "message":
           if (textBeforeCursor.match(/(repeated|required|optional)\s*\w*$/)) {
             const result = findMessageEnum(document);

--- a/src/proto3Suggest.ts
+++ b/src/proto3Suggest.ts
@@ -1,40 +1,51 @@
-'use strict';
+"use strict";
 
-import { tokenize } from 'protobufjs';
-import vscode = require('vscode');
-import { guessScope, Proto3ScopeKind } from './proto3ScopeGuesser';
+import { tokenize } from "protobufjs";
+import vscode = require("vscode");
+import { SyntacticGuessScope } from "./proto3SyntacticScopeGuesser";
 
-let kwSyntax = createCompletionKeyword('syntax');
-let kwPackage = createCompletionKeyword('package');
-let kwOption = createCompletionKeyword('option');
-let kwImport = createCompletionKeyword('import');
-let kwMessage = createCompletionKeyword('message');
-let kwEnum = createCompletionKeyword('enum');
-let kwReserved = createCompletionKeyword('reserved');
+let kwSyntax = createCompletionKeyword("syntax");
+let kwPackage = createCompletionKeyword("package");
+let kwOption = createCompletionKeyword("option");
+let kwImport = createCompletionKeyword("import");
+let kwMessage = createCompletionKeyword("message");
+let kwEnum = createCompletionKeyword("enum");
+let kwReserved = createCompletionKeyword("reserved");
 
 let fileOptions = [
-    createCompletionOption('java_package', `
+  createCompletionOption(
+    "java_package",
+    `
 Sets the Java package where classes generated from this .proto will be
 placed.  By default, the proto package is used, but this is often
 inappropriate because proto packages do not normally start with backwards
 domain names.
-    `),
-    createCompletionOption('java_outer_classname', `
+    `
+  ),
+  createCompletionOption(
+    "java_outer_classname",
+    `
 If set, all the classes from the .proto file are wrapped in a single
 outer class with the given name.  This applies to both Proto1
 (equivalent to the old "--one_java_file" option) and Proto2 (where
 a .proto always translates to a single class, but you may want to
 explicitly choose the class name).
-    `),
-    createCompletionOption('java_multiple_files', `
+    `
+  ),
+  createCompletionOption(
+    "java_multiple_files",
+    `
 If set true, then the Java code generator will generate a separate .java
 file for each top-level message, enum, and service defined in the .proto
 file.  Thus, these types will *not* be nested inside the outer class
 named by java_outer_classname.  However, the outer class will still be
 generated to contain the file's getDescriptor() method as well as any
 top-level extensions defined in the file.
-    `),
-    createCompletionOption('java_generate_equals_and_hash', `
+    `
+  ),
+  createCompletionOption(
+    "java_generate_equals_and_hash",
+    `
 If set true, then the Java code generator will generate equals() and
 hashCode() methods for all messages defined in the .proto file.
 This increases generated code size, potentially substantially for large
@@ -47,78 +58,114 @@ equals() and hashCode() to more closely match those of the full runtime;
 the generated methods compute their results based on field values rather
 than object identity. (Implementations should not assume that hashcodes
 will be consistent across runtimes or versions of the protocol compiler.)
-    `),
-    createCompletionOption('java_string_check_utf8', `
+    `
+  ),
+  createCompletionOption(
+    "java_string_check_utf8",
+    `
 If set true, then the Java2 code generator will generate code that
 throws an exception whenever an attempt is made to assign a non-UTF-8
 byte sequence to a string field.
 Message reflection will do the same.
 However, an extension field still accepts non-UTF-8 byte sequences.
 This option has no effect on when used with the lite runtime.
-    `),
-    createCompletionOption('optimize_for', `
+    `
+  ),
+  createCompletionOption(
+    "optimize_for",
+    `
 Generated classes can be optimized for speed or code size.
-    `),
-    createCompletionOption('go_package', `
+    `
+  ),
+  createCompletionOption(
+    "go_package",
+    `
 Sets the Go package where structs generated from this .proto will be
 placed. If omitted, the Go package will be derived from the following:
   - The basename of the package import path, if provided.
   - Otherwise, the package statement in the .proto file, if present.
   - Otherwise, the basename of the .proto file, without extension.
-    `),
-    //createCompletionOption('cc_generic_services'),
-    //createCompletionOption('java_generic_services'),
-    //createCompletionOption('py_generic_services'),
-    createCompletionOption('deprecated', `
+    `
+  ),
+  //createCompletionOption('cc_generic_services'),
+  //createCompletionOption('java_generic_services'),
+  //createCompletionOption('py_generic_services'),
+  createCompletionOption(
+    "deprecated",
+    `
 Is this file deprecated?
 Depending on the target platform, this can emit Deprecated annotations
 for everything in the file, or it will be completely ignored; in the very
 least, this is a formalization for deprecating files.
-    `),
-    createCompletionOption('cc_enable_arenas', `
+    `
+  ),
+  createCompletionOption(
+    "cc_enable_arenas",
+    `
 Enables the use of arenas for the proto messages in this file. This applies
 only to generated classes for C++.
-    `),
-    createCompletionOption('objc_class_prefix', `
+    `
+  ),
+  createCompletionOption(
+    "objc_class_prefix",
+    `
 Sets the objective c class prefix which is prepended to all objective c
 generated classes from this .proto. There is no default.
-    `),
-    createCompletionOption('csharp_namespace', `
+    `
+  ),
+  createCompletionOption(
+    "csharp_namespace",
+    `
 Namespace for generated classes; defaults to the package.
-    `),
+    `
+  ),
 ];
 
 let msgOptions = [
-    createCompletionOption('message_set_wire_format', `
+  createCompletionOption(
+    "message_set_wire_format",
+    `
 Set true to use the old proto1 MessageSet wire format for extensions.
 This is provided for backwards-compatibility with the MessageSet wire
 format.  You should not use this for any other reason:  It's less
 efficient, has fewer features, and is more complicated.
-    `),
-    createCompletionOption('no_standard_descriptor_accessor', `
+    `
+  ),
+  createCompletionOption(
+    "no_standard_descriptor_accessor",
+    `
 Disables the generation of the standard "descriptor()" accessor, which can
 conflict with a field of the same name.  This is meant to make migration
 from proto1 easier; new code should avoid fields named "descriptor".
-    `),
-    createCompletionOption('deprecated', `
+    `
+  ),
+  createCompletionOption(
+    "deprecated",
+    `
 Is this message deprecated?
 Depending on the target platform, this can emit Deprecated annotations
 for the message, or it will be completely ignored; in the very least,
 this is a formalization for deprecating messages.
-    `),
-    //createCompletionOption('map_entry', ``),
+    `
+  ),
+  //createCompletionOption('map_entry', ``),
 ];
 
 let fieldOptions = [
-    //createCompletionOption('ctype', ``),
-    createCompletionOption('packed', `
+  //createCompletionOption('ctype', ``),
+  createCompletionOption(
+    "packed",
+    `
 The packed option can be enabled for repeated primitive fields to enable
 a more efficient representation on the wire. Rather than repeatedly
 writing the tag and type for each element, the entire array is encoded as
 a single length-delimited blob. In proto3, only explicit setting it to
 false will avoid using packed encoding.
-    `),
-    createCompletionOption('jstype', `
+    `
+  ),
+  createCompletionOption(
+    "jstype",
+    `
 The jstype option determines the JavaScript type used for values of the
 field.  The option is permitted only for 64 bit integral and fixed types
 (int64, uint64, sint64, fixed64, sfixed64).  By default these types are
@@ -128,8 +175,11 @@ numbers.  Specifying JS_NUMBER for the jstype causes the generated
 JavaScript code to use the JavaScript "number" type instead of strings.
 This option is an enum to permit additional types to be added,
 e.g. goog.math.Integer.
-    `),
-    createCompletionOption('lazy', `
+    `
+  ),
+  createCompletionOption(
+    "lazy",
+    `
 Should this field be parsed lazily?  Lazy applies only to message-type
 fields.  It means that when the outer message is initially parsed, the
 inner message's contents will not be parsed but instead stored in encoded
@@ -158,210 +208,250 @@ must be consistent about it.  That is, for any particular sub-message, the
 implementation must either *always* check its required fields, or *never*
 check its required fields, regardless of whether or not the message has
 been parsed.
-    `),
-    createCompletionOption('deprecated', `
+    `
+  ),
+  createCompletionOption(
+    "deprecated",
+    `
 Is this field deprecated?
 Depending on the target platform, this can emit Deprecated annotations
 for accessors, or it will be completely ignored; in the very least, this
 is a formalization for deprecating fields.
-    `),
+    `
+  ),
 ];
 
-let fieldDefault = createCompletionOption('default', ``);
+let fieldDefault = createCompletionOption("default", ``);
 
 let enumOptions = [
-    createCompletionOption('allow_alias', `
+  createCompletionOption(
+    "allow_alias",
+    `
 Set this option to true to allow mapping different tag names to the same
 value.
-    `),
-    createCompletionOption('deprecated', `
+    `
+  ),
+  createCompletionOption(
+    "deprecated",
+    `
 Is this enum deprecated?
 Depending on the target platform, this can emit Deprecated annotations
 for the enum, or it will be completely ignored; in the very least, this
 is a formalization for deprecating enums.
-    `),
+    `
+  ),
 ];
 
 let enumValueOptions = [
-    createCompletionOption('deprecated', `
+  createCompletionOption(
+    "deprecated",
+    `
 Is this enum value deprecated?
 Depending on the target platform, this can emit Deprecated annotations
 for the enum value, or it will be completely ignored; in the very least,
 this is a formalization for deprecating enum values.
-    `),
+    `
+  ),
 ];
 
 let serviceOptions = [
-    createCompletionOption('deprecated', `
+  createCompletionOption(
+    "deprecated",
+    `
 Is this service deprecated?
 Depending on the target platform, this can emit Deprecated annotations
 for the service, or it will be completely ignored; in the very least,
 this is a formalization for deprecating services.
-    `),
+    `
+  ),
 ];
 
 let fieldRules = [
-    createCompletionKeyword('repeated'),
-    createCompletionKeyword('required'),
-    createCompletionKeyword('optional'),
+  createCompletionKeyword("repeated"),
+  createCompletionKeyword("required"),
+  createCompletionKeyword("optional"),
 ];
 
-let scalaTypes = [
-    createCompletionKeyword('bool', ``),
-    createCompletionKeyword('int32', `
+let scalarTypes = [
+  createCompletionKeyword("bool", ``),
+  createCompletionKeyword(
+    "int32",
+    `
 Uses variable-length encoding. 
 Inefficient for encoding negative numbers – if your field is likely to have 
 negative values, use sint32 instead.`
-    ),
-    createCompletionKeyword('int64', `
+  ),
+  createCompletionKeyword(
+    "int64",
+    `
 Uses variable-length encoding. 
 Inefficient for encoding negative numbers – if your field is likely to have 
 negative values, use sint64 instead.    
-    `),
-    createCompletionKeyword('uint32', `Uses variable-length encoding.`),
-    createCompletionKeyword('uint64', `Uses variable-length encoding.`),
-    createCompletionKeyword('sint32', `
+    `
+  ),
+  createCompletionKeyword("uint32", `Uses variable-length encoding.`),
+  createCompletionKeyword("uint64", `Uses variable-length encoding.`),
+  createCompletionKeyword(
+    "sint32",
+    `
 Uses variable-length encoding. 
 Signed int value. 
 These more efficiently encode negative numbers than regular int32s.    
-    `),
-    createCompletionKeyword('sint64', `
+    `
+  ),
+  createCompletionKeyword(
+    "sint64",
+    `
 Uses variable-length encoding. 
 Signed int value. 
 These more efficiently encode negative numbers than regular int64s.    
-    `),
-    createCompletionKeyword('fixed32', `
+    `
+  ),
+  createCompletionKeyword(
+    "fixed32",
+    `
 Always four bytes. 
 More efficient than uint32 if values are often greater than 2^28.    
-    `),
-    createCompletionKeyword('fixed64', `
+    `
+  ),
+  createCompletionKeyword(
+    "fixed64",
+    `
 Always eight bytes. 
 More efficient than uint64 if values are often greater than 2^56.    
-    `),
-    createCompletionKeyword('sfixed32', `Always four bytes.`),
-    createCompletionKeyword('sfixed64', `Always eight bytes.`),
-    createCompletionKeyword('float', ``),
-    createCompletionKeyword('double', ``),
-    createCompletionKeyword('string', `
+    `
+  ),
+  createCompletionKeyword("sfixed32", `Always four bytes.`),
+  createCompletionKeyword("sfixed64", `Always eight bytes.`),
+  createCompletionKeyword("float", ``),
+  createCompletionKeyword("double", ``),
+  createCompletionKeyword(
+    "string",
+    `
 A string must always contain UTF-8 encoded or 7-bit ASCII text.
-    `),
-    createCompletionKeyword('bytes', `
+    `
+  ),
+  createCompletionKeyword(
+    "bytes",
+    `
 May contain any arbitrary sequence of bytes.
-    `),
+    `
+  ),
 ];
 
 function createCompletionKeyword(label: string, doc?: string): vscode.CompletionItem {
-    let item = new vscode.CompletionItem(label);
-    item.kind = vscode.CompletionItemKind.Keyword;
-    if (doc) {
-        item.documentation = doc;
-    }
-    return item
+  let item = new vscode.CompletionItem(label);
+  item.kind = vscode.CompletionItemKind.Keyword;
+  if (doc) {
+    item.documentation = doc;
+  }
+  return item;
 }
 
 function createCompletionOption(option: string, doc: string): vscode.CompletionItem {
-    let item = new vscode.CompletionItem(option);
-    item.kind = vscode.CompletionItemKind.Value;
-    item.documentation = doc;
-    return item
+  let item = new vscode.CompletionItem(option);
+  item.kind = vscode.CompletionItemKind.Value;
+  item.documentation = doc;
+  return item;
 }
 
 // not very efficiently.
 function findMessages(document: vscode.TextDocument): vscode.CompletionItem[] {
-    const result: vscode.CompletionItem[] = [];
-    const tokenizer = tokenize(document.getText(), false)
-    for (let tok = tokenizer.next(); tok !== null; tok = tokenizer.next()) {
-        if (tok === 'message') {
-            // find identifiers after `message` keyword
-            const identifier = tokenizer.peek();
-            if (identifier !== null && /^[a-zA-Z_]+\w*$/.test(identifier)) {
-                const item = new vscode.CompletionItem(identifier, vscode.CompletionItemKind.Struct);
-                // should extract message declaration and comments here
-                result.push(item);
-            }
-        }
+  const result: vscode.CompletionItem[] = [];
+  const tokenizer = tokenize(document.getText(), false);
+  for (let tok = tokenizer.next(); tok !== null; tok = tokenizer.next()) {
+    if (tok === "message") {
+      // find identifiers after `message` keyword
+      const identifier = tokenizer.peek();
+      if (identifier !== null && /^[a-zA-Z_]+\w*$/.test(identifier)) {
+        const item = new vscode.CompletionItem(identifier, vscode.CompletionItemKind.Struct);
+        // should extract message declaration and comments here
+        result.push(item);
+      }
     }
+  }
 
-    return result
+  return result;
 }
 
 export class Proto3CompletionItemProvider implements vscode.CompletionItemProvider {
+  public provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): Thenable<vscode.CompletionItem[]> {
+    return new Promise<vscode.CompletionItem[]>((resolve, reject) => {
+      let syntax = 2;
+      const matches = document.getText().match(/syntax\s*=\s*"(proto2|proto3)"/);
+      if (matches.length >= 2 && matches[1] === "proto3") {
+        syntax = 3;
+      }
 
-    public provideCompletionItems(document: vscode.TextDocument,
-        position: vscode.Position,
-        token: vscode.CancellationToken)
-        : Thenable<vscode.CompletionItem[]> {
+      const textBeforeCursor = document.lineAt(position.line).text.substring(0, position.character - 1);
+      const suggestions: vscode.CompletionItem[] = [];
+      const scope = SyntacticGuessScope(document, position);
 
-        return new Promise<vscode.CompletionItem[]>((resolve, reject) => {
-            let filename = document.fileName;
-            let lineText = document.lineAt(position.line).text;
+      console.log(scope);
 
-            if (lineText.match(/^\s*\/\//)) {
-                return resolve([]);
+      if (scope === null) {
+        suggestions.push(kwSyntax);
+        suggestions.push(kwPackage);
+        suggestions.push(kwOption);
+        suggestions.push(kwImport);
+        suggestions.push(kwMessage);
+        suggestions.push(kwEnum);
+        if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
+          suggestions.push(...fileOptions);
+        }
+        return resolve(suggestions);
+      }
+
+      switch (scope.name) {
+        case "message":
+          if (textBeforeCursor.match(/(repeated|required|optional)\s*\w*$/)) {
+            suggestions.push(...scalarTypes, ...findMessages(document));
+          } else if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
+            suggestions.push(...msgOptions);
+          } else if (textBeforeCursor.match(/.*\[.*/)) {
+            suggestions.push(...fieldOptions);
+            if (syntax == 2) {
+              suggestions.push(fieldDefault);
             }
+          }
 
-            let inString = false;
-            if ((lineText.substring(0, position.character).match(/\"/g) || []).length % 2 === 1) {
-                inString = true;
-            }
-
-            let suggestions = [];
-
-            let textBeforeCursor = lineText.substring(0, position.character - 1)
-            let scope = guessScope(document, position.line);
-            //console.log(scope.syntax);
-            //console.log(textBeforeCursor);
-
-            switch (scope.kind) {
-                case Proto3ScopeKind.Proto: {
-                    if (textBeforeCursor.match(/^\s*\w*$/)) {
-                        suggestions.push(kwSyntax);
-                        suggestions.push(kwPackage);
-                        suggestions.push(kwOption);
-                        suggestions.push(kwImport);
-                        suggestions.push(kwMessage);
-                        suggestions.push(kwEnum);
-                    } else if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
-                        suggestions.push(...fileOptions);
-                    }
-                    break;
-                }
-                case Proto3ScopeKind.Message: {
-                    if (textBeforeCursor.match(/^\s*\w*$/)) {
-                        suggestions.push(kwOption);
-                        suggestions.push(kwMessage);
-                        suggestions.push(kwEnum);
-                        suggestions.push(kwReserved);
-                        if (scope.syntax == 2) {
-                            suggestions.push(...fieldRules);
-                        } else {
-                            suggestions.push(fieldRules[0]);
-                        }
-                        suggestions.push(...scalaTypes, ...findMessages(document));
-                    } else if (textBeforeCursor.match(/(repeated|required|optional)\s*\w*$/)) {
-                        suggestions.push(...scalaTypes, ...findMessages(document));
-                    } else if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
-                        suggestions.push(...msgOptions);
-                    } else if (textBeforeCursor.match(/.*\[.*/)) {
-                        suggestions.push(...fieldOptions);
-                        if (scope.syntax == 2) {
-                            suggestions.push(fieldDefault);
-                        }
-                    }
-                    break;
-                }
-                case Proto3ScopeKind.Enum: {
-                    if (textBeforeCursor.match(/^\s*\w*$/)) {
-                        suggestions.push(kwOption);
-                    } else if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
-                        suggestions.push(...enumOptions);
-                    }
-                    break;
-                }
-            }
-
-            return resolve(suggestions);
-        });
-    }
-
+          suggestions.push(kwOption);
+          suggestions.push(kwMessage);
+          suggestions.push(kwEnum);
+          suggestions.push(kwReserved);
+          if (syntax == 2) {
+            suggestions.push(...fieldRules);
+          } else {
+            suggestions.push(fieldRules[0]);
+          }
+          suggestions.push(...scalarTypes, ...findMessages(document));
+          break;
+        case "enum":
+          if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
+            suggestions.push(...enumOptions);
+          } else {
+            suggestions.push(kwOption);
+          }
+          break;
+        case "rpcbody":
+          if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
+            suggestions.push(...serviceOptions);
+          } else {
+            suggestions.push(kwOption);
+          }
+          break;
+        case "rpc":
+        case "returns":
+          suggestions.push(...scalarTypes, ...findMessages(document));
+          break;
+        default:
+          break;
+      }
+      return resolve(suggestions);
+    });
+  }
 }

--- a/src/proto3Suggest.ts
+++ b/src/proto3Suggest.ts
@@ -408,13 +408,16 @@ export class Proto3CompletionItemProvider implements vscode.CompletionItemProvid
         case "message":
           if (textBeforeCursor.match(/(repeated|required|optional)\s*\w*$/)) {
             suggestions.push(...scalarTypes, ...findMessages(document));
+            return resolve(suggestions);
           } else if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
             suggestions.push(...msgOptions);
+            return resolve(suggestions);
           } else if (textBeforeCursor.match(/.*\[.*/)) {
             suggestions.push(...fieldOptions);
             if (syntax == 2) {
               suggestions.push(fieldDefault);
             }
+            return resolve(suggestions);
           }
 
           suggestions.push(kwOption);

--- a/src/proto3Suggest.ts
+++ b/src/proto3Suggest.ts
@@ -391,8 +391,6 @@ export class Proto3CompletionItemProvider implements vscode.CompletionItemProvid
       const suggestions: vscode.CompletionItem[] = [];
       const scope = SyntacticGuessScope(document, position);
 
-      console.log(scope);
-
       if (scope === null) {
         suggestions.push(kwSyntax);
         suggestions.push(kwPackage);

--- a/src/proto3Suggest.ts
+++ b/src/proto3Suggest.ts
@@ -419,7 +419,7 @@ export class Proto3CompletionItemProvider implements vscode.CompletionItemProvid
 
       switch (scope.name) {
         case "service":
-          if (textBeforeCursor.match(/^\s*option\s+\(?\w*$/)) {
+          if (textBeforeCursor.match(/^\s*option(\s*\(?|\s)\s*\w*$/)) {
             suggestions.push(...serviceOptions);
           } else {
             suggestions.push(kwRpc);
@@ -431,7 +431,7 @@ export class Proto3CompletionItemProvider implements vscode.CompletionItemProvid
             const result = findMessageEnum(document);
             suggestions.push(...scalarTypes, ...result.enum, ...result.message);
             return resolve(suggestions);
-          } else if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
+          } else if (textBeforeCursor.match(/^\s*option(\s*\(?|\s)\s*\w*$/)) {
             suggestions.push(...msgOptions);
             return resolve(suggestions);
           } else if (textBeforeCursor.match(/.*\[.*/)) {
@@ -455,14 +455,14 @@ export class Proto3CompletionItemProvider implements vscode.CompletionItemProvid
           suggestions.push(...scalarTypes, ...result.enum, ...result.message);
           break;
         case "enum":
-          if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
+          if (textBeforeCursor.match(/^\s*option(\s*\(?|\s)\s*\w*$/)) {
             suggestions.push(...enumOptions);
           } else {
             suggestions.push(kwOption);
           }
           break;
         case "rpcbody":
-          if (textBeforeCursor.match(/^\s*option\s+\w*$/)) {
+          if (textBeforeCursor.match(/^\s*option(\s*\(?|\s)\s*\w*$/)) {
             suggestions.push(...serviceOptions);
           } else {
             suggestions.push(kwOption);

--- a/src/proto3SyntacticScopeGuesser.ts
+++ b/src/proto3SyntacticScopeGuesser.ts
@@ -1,0 +1,220 @@
+import { ITokenizerHandle, tokenize } from "protobufjs";
+import * as vscode from "vscode";
+
+class position {
+  constructor(public line: number, public col: number) {}
+
+  static from(pos: position): position {
+    return Object.assign(new position(0, 0), pos);
+  }
+}
+
+class token {
+  constructor(public tok: string, public pos: position) {}
+}
+
+class tokenizer {
+  private _pos: position = new position(0, 0);
+  private _token_width: number = 0;
+  private _handler: ITokenizerHandle;
+
+  constructor(public doc: vscode.TextDocument) {
+    this._handler = tokenize(doc.getText(), false);
+  }
+
+  public peek(): token | null {
+    const tok = this._handler.peek();
+    if (tok == null) {
+      return null;
+    }
+
+    let row = this._handler.line,
+      col = this._pos.col;
+    if (row !== this._pos.line) {
+      col = 0;
+    }
+    col = this.doc.lineAt(row).text.indexOf(tok, this._pos.col);
+    return new token(tok, new position(row, col));
+  }
+
+  public next(): token | null {
+    const tok = this._handler.next();
+    if (tok === null) {
+      return null;
+    }
+
+    const lineno = this._handler.line;
+    if (lineno !== this._pos.line) {
+      this._pos = new position(lineno, 0);
+      this._token_width = 0;
+    }
+
+    // 注意 vscode 的行号是从0开始的，protobufjs 的 tokenize 返回的行号是从 1 开始的
+    this._pos.col = this.doc.lineAt(lineno - 1).text.indexOf(tok, this._pos.col + this._token_width);
+    this._token_width = tok.length;
+
+    return new token(tok, position.from(this._pos));
+  }
+
+  public peek_expect(regexp: RegExp): token | null {
+    const t = this.peek();
+    if (t === null) {
+      return null;
+    }
+
+    if (regexp.test(t.tok)) {
+      return t;
+    }
+
+    return null;
+  }
+
+  public expect(regexp: RegExp): token | null {
+    const t = this.next();
+    if (t === null) {
+      return null;
+    }
+    if (regexp.test(t.tok)) {
+      throw new Error("unexpected token");
+    }
+    return t;
+  }
+
+  public get position(): position {
+    return position.from(this._pos);
+  }
+}
+
+class scope {
+  constructor(
+    public name: "message" | "enum" | "service" | "rpc" | "returns" | "rpcbody" | "",
+    public sym: "(" | "{",
+    public pos: position,
+    public end: position = null
+  ) {}
+}
+
+// check is pos inside range(begin,end)
+function isContains(pos: position, begin: position, end: position) {
+  // scope 起止都在同一行，光标在起止范围内
+  return (
+    (begin.line === end.line && begin.line === pos.line && pos.col >= begin.col && pos.col <= end.col) ||
+    // scope 不在同一行，光标在起始行的起始token后
+    (begin.line !== end.line && begin.line === pos.line && pos.col >= begin.col) ||
+    // scope 不在同一行，光标在结束行的结束token前
+    (begin.line !== end.line && end.line === pos.line && pos.col <= end.col) ||
+    // scope 不在同一行，光标在起始行和结束行中间
+    (begin.line !== end.line && pos.line < end.line && pos.line > begin.line)
+  );
+}
+
+// 全局返回 null
+// 其他情况返回 scope
+export function SyntacticGuessScope(document: vscode.TextDocument, cursorPosition: vscode.Position): scope | null {
+  const stack: scope[] = [];
+  const tkn = new tokenizer(document);
+  for (let tok = tkn.next(); tok !== null; tok = tkn.next()) {
+    switch (tok.tok) {
+      case "message": {
+        // take next token until reach left brace
+        let t = tkn.next();
+        for (; t !== null && t.tok !== "{"; t = tkn.next()) {}
+        stack.push(new scope("message", "{", position.from(t.pos)));
+
+        break;
+      }
+      case "enum": {
+        // take next token until reach left brace
+        let t = tkn.next();
+        for (; t !== null && t.tok !== "{"; t = tkn.next()) {}
+        stack.push(new scope("enum", "{", position.from(t.pos)));
+        break;
+      }
+      case "rpc": {
+        // take next token until reach left paren
+        let t = tkn.next();
+        for (; t !== null && t.tok !== "("; t = tkn.next()) {}
+        stack.push(new scope("rpc", "(", position.from(t.pos)));
+        break;
+      }
+      case "returns": {
+        // take next token until reach left paren
+        let t = tkn.next();
+        for (; t !== null && t.tok !== "("; t = tkn.next()) {}
+        stack.push(new scope("returns", "(", position.from(t.pos)));
+        break;
+      }
+      case "service": {
+        // take next token until reach left brace
+        let t = tkn.next();
+        for (; t !== null && t.tok !== "{"; t = tkn.next()) {}
+        stack.push(new scope("service", "{", position.from(t.pos)));
+        break;
+      }
+      case "(":
+        stack.push(new scope("", "(", position.from(tok.pos)));
+        break;
+      case "{":
+        stack.push(new scope("", "{", position.from(tok.pos)));
+        break;
+      case "}": {
+        // 匹配栈顶的符号并且是我们关注的 scope 类型 (name!=='')，此时才开始检查光标位置是不是在 scope 区间内
+        const lastScope = stack[stack.length - 1];
+        if (lastScope.sym === "{") {
+          stack.pop();
+
+          if (lastScope.name !== "") {
+            // 光标在范围内直接返回
+            // 注意 vscode 的行号是从0开始的，protobufjs 的 tokenize 返回的行号是从 1 开始的
+            if (isContains(new position(cursorPosition.line + 1, cursorPosition.character), lastScope.pos, tok.pos)) {
+              lastScope.end = position.from(tok.pos);
+              return lastScope;
+            }
+          }
+        } else {
+          // mismatch!
+          return null;
+        }
+        break;
+      }
+      case ")": {
+        // 匹配栈顶的符号并且是我们关注的 scope 类型 (name!=='')，此时才开始检查光标位置是不是在 scope 区间内
+        const lastScope = stack[stack.length - 1];
+        if (lastScope.sym === "(") {
+          stack.pop();
+
+          if (lastScope.name !== "") {
+            // 光标在范围内直接返回
+            // 注意 vscode 的行号是从0开始的，protobufjs 的 tokenize 返回的行号是从 1 开始的
+            const cursor = new position(cursorPosition.line + 1, cursorPosition.character);
+            if (isContains(cursor, lastScope.pos, tok.pos)) {
+              lastScope.end = position.from(tok.pos);
+              return lastScope;
+            }
+
+            // 针对rpc 的 option
+            if (lastScope.name === "returns") {
+              if (tkn.peek().tok === "{") {
+                const t = tkn.next();
+                stack.push(new scope("rpcbody", "{", position.from(t.pos)));
+              }
+            }
+          }
+        } else {
+          // mismatch!
+          return null;
+        }
+        break;
+      }
+    }
+  }
+
+  while (stack.length > 0) {
+    const lastScope = stack.pop();
+    if (lastScope.name !== "") {
+      return lastScope;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
![code-completion](https://user-images.githubusercontent.com/16402753/126754918-b12b461e-b17b-4ab1-a3f1-ed401e34698f.gif)

Improve code completion experience.

- add MessageType completion after `repeated` keyword
- add RequestType code completion (see gif above)
- add ResponseType code completion (see gif above)
- add rpc option completion (see gif above)

我还没有充分试用过，可能还有bug。