### PR TITLE
enhancement + bugfix

### DIFF
--- a/src/proto3Configuration.ts
+++ b/src/proto3Configuration.ts
@@ -44,7 +44,7 @@ export class Proto3Configuration {
     }
 
     public getProtocOptions(): string[] {
-        return this.getProtocArgs().filter(arg => arg.startsWith('-'));
+        return this.getProtocArgs();
     }
 
     public getProtoPathOptions(): string[] {


### PR DESCRIPTION
stop filtering parameters that start with - , reason: let's take the following scenario in my dart project i have a proto file called myprotos.proto that references google/protobuf/any.proto but in order for myprotos.proto to compile correctly any.proto needs to be given to --dart_out parameter.

//initial config any.proto will not be compiled (my proto references it with an import directive but not enough)
 "compile_all_path": "${workspaceRoot}/lib/logic/models/protos",
        "options": [
            "--proto_path=${workspaceRoot}/lib/logic/models/protos",
            "--dart_out=${workspaceRoot}/lib/logic/models/protos/gen", 
        ]


//config that compiles any.proto 
 "compile_all_path": "${workspaceRoot}/lib/logic/models/protos",
        "options": [
            "--proto_path=${workspaceRoot}/lib/logic/models/protos",
            "--dart_out=${workspaceRoot}/lib/logic/models/protos/gen",
            "D:/temp/protoc318/include/google/protobuf/any.proto"  //when running "compile this proto" option the extension appends the proto to these arguments, without 
                                                                                                             this change that i'm proposing this is not possible but its very necessary to correctly compile any.proto
        ]

--dart_out would look like :--dart_out=..../models/protos/gen ...../include/google/protobuf/any.proto .lib/logic/models/protos/myprotos.proto

A nasty workaround could be to manually copy the entire google/protobuf folder from protoc release to my dart project but its not ok.

google/protobuf/any.proto- >
https://developers.google.com/protocol-buffers/docs/reference/dart-generated#any