### PR TITLE
Faster "Go to symbol" by caching unchanged proto files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     },
     "exclude": [
         "node_modules",
-        ".vscode-test"
+        ".vscode-test",
+        "out"
     ]
 }


### PR DESCRIPTION
On a project with +500 LOC proto file, "Go to symbol" is painfully slow (many seconds before jump on my i7 ssd). I noticed the `protobuf.js:tokenize()` method is called on each proto file of the project before each jump, resulting in a expensive parsing pass. I implemented a very naive cache for the tokenizer result. It effectively reduces the "Go to symbol" delay to less than a second.