### PR TITLE
add additional syntax highlighting

### DIFF
--- a/syntaxes/proto3.tmLanguage.json
+++ b/syntaxes/proto3.tmLanguage.json
@@ -30,11 +30,12 @@
       ]
     },
     "syntax": {
-      "match": "\\s*(syntax)\\s*=\\s*(\"proto[23]\")\\s*(;)",
+      "match": "\\s*(syntax)\\s*(=)\\s*(\"proto[23]\")\\s*(;)",
       "captures": {
         "1": {"name": "keyword.other.proto"},
-        "2": {"name": "string.quoted.double.proto.syntax"},
-        "3": {"name": "punctuation.terminator.proto"}
+        "2": {"name": "keyword.operator.assignment.proto"},
+        "3": {"name": "string.quoted.double.proto.syntax"},
+        "4": {"name": "punctuation.terminator.proto"}
       }
     },
     "package": {
@@ -55,12 +56,13 @@
       }
     },
     "optionStmt": {
-      "begin": "(option)\\s+(\\w+|\\(\\w+(\\.\\w+)*\\))(\\.\\w+)*\\s*=",
+      "begin": "(option)\\s+(\\w+|\\(\\w+(\\.\\w+)*\\))(\\.\\w+)*\\s*(=)",
       "beginCaptures": {
         "1": {"name": "keyword.other.proto"},
         "2": {"name": "support.other.proto"},
         "3": {"name": "support.other.proto"},
-        "4": {"name": "support.other.proto"}
+        "4": {"name": "support.other.proto"},
+        "5": {"name": "keyword.operator.assignment.proto"}
       },
       "end": "(;)",
       "endCaptures": {
@@ -157,12 +159,13 @@
       ]
     },
     "field": {
-      "begin": "\\s*(optional|repeated|required)?\\s*\\b([\\w.]+)\\s+(\\w+)\\s*=\\s*(0[xX][0-9a-fA-F]+|[0-9]+)",
+      "begin": "\\s*(optional|repeated|required)?\\s*\\b([\\w.]+)\\s+(\\w+)\\s*(=)\\s*(0[xX][0-9a-fA-F]+|[0-9]+)",
       "beginCaptures": {
         "1": {"name": "storage.modifier.proto"},
         "2": {"name": "storage.type.proto"},
         "3": {"name": "variable.other.proto"},
-        "4": {"name": "constant.numeric.proto"}
+        "4": {"name": "keyword.operator.assignment.proto"},
+        "5": {"name": "constant.numeric.proto"}
       },
       "end": "(;)",
       "endCaptures": {
@@ -173,7 +176,7 @@
       ]
     },
     "mapfield": {
-      "begin": "\\s*(map)\\s*(<)\\s*([\\w.]+)\\s*,\\s*([\\w.]+)\\s*(>)\\s+(\\w+)\\s*=\\s*(\\d+)",
+      "begin": "\\s*(map)\\s*(<)\\s*([\\w.]+)\\s*,\\s*([\\w.]+)\\s*(>)\\s+(\\w+)\\s*(=)\\s*(\\d+)",
       "beginCaptures": {
         "1": {"name": "storage.type.proto"},
         "2": {"name": "punctuation.definition.typeparameters.begin.proto"},
@@ -181,7 +184,8 @@
         "4": {"name": "storage.type.proto"},
         "5": {"name": "punctuation.definition.typeparameters.end.proto"},
         "6": {"name": "variable.other.proto"},
-        "7": {"name": "constant.numeric.proto"}
+        "7": {"name": "keyword.operator.assignment.proto"},
+        "8": {"name": "constant.numeric.proto"}
       },
       "end": "(;)",
       "endCaptures": {
@@ -216,10 +220,11 @@
         {"include": "#optionStmt"},
         {"include": "#comments"},
         {
-          "begin": "([A-Za-z][A-Za-z0-9_]*)\\s*=\\s*(0[xX][0-9a-fA-F]+|[0-9]+)",
+          "begin": "([A-Za-z][A-Za-z0-9_]*)\\s*(=)\\s*(0[xX][0-9a-fA-F]+|[0-9]+)",
           "beginCaptures": {
             "1": {"name": "variable.other.proto"},
-            "2": {"name": "constant.numeric.proto"}
+            "2": {"name": "keyword.operator.assignment.proto"},
+            "3": {"name": "constant.numeric.proto"}
           },
           "end": "(;)",
           "endCaptures": {

--- a/syntaxes/proto3.tmLanguage.json
+++ b/syntaxes/proto3.tmLanguage.json
@@ -172,13 +172,15 @@
       ]
     },
     "mapfield": {
-      "begin": "\\s*(map)\\s*<\\s*([\\w.]+)\\s*,\\s*([\\w.]+)\\s*>\\s+(\\w+)\\s*=\\s*(\\d+)",
+      "begin": "\\s*(map)\\s*(<)\\s*([\\w.]+)\\s*,\\s*([\\w.]+)\\s*(>)\\s+(\\w+)\\s*=\\s*(\\d+)",
       "beginCaptures": {
         "1": {"name": "storage.type.proto"},
-        "2": {"name": "storage.type.proto"},
+        "2": {"name": "punctuation.definition.typeparameters.proto"},
         "3": {"name": "storage.type.proto"},
-        "4": {"name": "variable.other.proto"},
-        "5": {"name": "constant.numeric.proto"}
+        "4": {"name": "storage.type.proto"},
+        "5": {"name": "punctuation.definition.typeparameters.proto"},
+        "6": {"name": "variable.other.proto"},
+        "7": {"name": "constant.numeric.proto"}
       },
       "end": "(;)",
       "endCaptures": {

--- a/syntaxes/proto3.tmLanguage.json
+++ b/syntaxes/proto3.tmLanguage.json
@@ -176,10 +176,10 @@
       "begin": "\\s*(map)\\s*(<)\\s*([\\w.]+)\\s*,\\s*([\\w.]+)\\s*(>)\\s+(\\w+)\\s*=\\s*(\\d+)",
       "beginCaptures": {
         "1": {"name": "storage.type.proto"},
-        "2": {"name": "punctuation.definition.typeparameters.proto"},
+        "2": {"name": "punctuation.definition.typeparameters.begin.proto"},
         "3": {"name": "storage.type.proto"},
         "4": {"name": "storage.type.proto"},
-        "5": {"name": "punctuation.definition.typeparameters.proto"},
+        "5": {"name": "punctuation.definition.typeparameters.end.proto"},
         "6": {"name": "variable.other.proto"},
         "7": {"name": "constant.numeric.proto"}
       },

--- a/syntaxes/proto3.tmLanguage.json
+++ b/syntaxes/proto3.tmLanguage.json
@@ -30,25 +30,28 @@
       ]
     },
     "syntax": {
-      "match": "\\s*(syntax)\\s*=\\s*(\"proto[23]\")\\s*;",
+      "match": "\\s*(syntax)\\s*=\\s*(\"proto[23]\")\\s*(;)",
       "captures": {
         "1": {"name": "keyword.other.proto"},
-        "2": {"name": "string.quoted.double.proto.syntax"}
+        "2": {"name": "string.quoted.double.proto.syntax"},
+        "3": {"name": "punctuation.terminator.proto"}
       }
     },
     "package": {
-      "match": "\\s*(package)\\s+([\\w.]+)\\s*;",
+      "match": "\\s*(package)\\s+([\\w.]+)\\s*(;)",
       "captures": {
         "1": {"name": "keyword.other.proto"},
-        "2": {"name": "string.unquoted.proto.package"}
+        "2": {"name": "string.unquoted.proto.package"},
+        "3": {"name": "punctuation.terminator.proto"}
       }
     },
     "import": {
-      "match": "\\s*(import)\\s+(weak|public)?\\s*(\"[^\"]+\")\\s*;",
+      "match": "\\s*(import)\\s+(weak|public)?\\s*(\"[^\"]+\")\\s*(;)",
       "captures": {
         "1": {"name": "keyword.other.proto"},
         "2": {"name": "keyword.other.proto"},
-        "3": {"name": "string.quoted.double.proto.import"}
+        "3": {"name": "string.quoted.double.proto.import"},
+        "4": {"name": "punctuation.terminator.proto"}
       }
     },
     "optionStmt": {
@@ -59,7 +62,10 @@
         "3": {"name": "support.other.proto"},
         "4": {"name": "support.other.proto"}
       },
-      "end": ";",
+      "end": "(;)",
+      "endCaptures": {
+        "1": {"name": "punctuation.terminator.proto"}
+      },
       "patterns": [
         {"include": "#constants"},
         {"include": "#number"},
@@ -80,7 +86,10 @@
       "beginCaptures": {
         "1": {"name": "keyword.other.proto"}
       },
-      "end": ";|,|(?=[}/_a-zA-Z])",
+      "end": "(;)|,|(?=[}/_a-zA-Z])",
+      "endCaptures": {
+        "1": {"name": "punctuation.terminator.proto"}
+      },
       "patterns": [
         {"include": "#constants"},
         {"include": "#number"},
@@ -130,7 +139,10 @@
       "beginCaptures": {
         "1": {"name": "keyword.other.proto"}
       },
-      "end": ";",
+      "end": "(;)",
+      "endCaptures": {
+        "1": {"name": "punctuation.terminator.proto"}
+      },
       "patterns": [
         {
           "match": "(\\d+)(\\s+(to)\\s+(\\d+))?",
@@ -151,7 +163,10 @@
         "3": {"name": "variable.other.proto"},
         "4": {"name": "constant.numeric.proto"}
       },
-      "end": ";",
+      "end": "(;)",
+      "endCaptures": {
+        "1": {"name": "punctuation.terminator.proto"}
+      },
       "patterns": [
         {"include": "#fieldOptions"}
       ]
@@ -165,7 +180,10 @@
         "4": {"name": "variable.other.proto"},
         "5": {"name": "constant.numeric.proto"}
       },
-      "end": ";",
+      "end": "(;)",
+      "endCaptures": {
+        "1": {"name": "punctuation.terminator.proto"}
+      },
       "patterns": [
         {"include": "#fieldOptions"}
       ]
@@ -200,7 +218,10 @@
             "1": {"name": "variable.other.proto"},
             "2": {"name": "constant.numeric.proto"}
           },
-          "end": ";",
+          "end": "(;)",
+          "endCaptures": {
+            "1": {"name": "punctuation.terminator.proto"}
+          },
           "patterns": [
             {"include": "#fieldOptions"}
           ]
@@ -226,7 +247,10 @@
         "1": {"name": "keyword.other.proto"},
         "2": {"name": "entity.name.function"}
       },
-      "end": "\\}|;",
+      "end": "\\}|(;)",
+      "endCaptures": {
+        "1": {"name": "punctuation.terminator.proto"}
+      },
       "patterns": [
         {"include": "#comments"},
         {"include": "#optionStmt"},

--- a/syntaxes/proto3.tmLanguage.json
+++ b/syntaxes/proto3.tmLanguage.json
@@ -82,9 +82,10 @@
       ]
     },
     "kv": {
-      "begin": "(\\w+)\\s*:",
+      "begin": "(\\w+)\\s*(:)",
       "beginCaptures": {
-        "1": {"name": "keyword.other.proto"}
+        "1": {"name": "keyword.other.proto"},
+        "2": {"name": "punctuation.separator.key-value.proto"}
       },
       "end": "(;)|,|(?=[}/_a-zA-Z])",
       "endCaptures": {


### PR DESCRIPTION
Added the following syntax scopes:

- `keyword.operator.assignment.proto` (equals signs)
- `punctuation.terminator.proto` (semicolons)
- `punctuation.definition.typeparameters.proto` (angle brackets)
- `punctuation.separator.key-value.proto` (colons)

These changes are small, but allow developers to make more precise color themes.

For example: 

## Before

<img width="1680" alt="Screen Shot 2022-02-08 at 1 56 46 PM" src="https://user-images.githubusercontent.com/51792731/153065583-d27208bd-f132-4a75-b847-194b8c4805cf.png">

## After

<img width="1680" alt="Screen Shot 2022-02-08 at 1 56 53 PM" src="https://user-images.githubusercontent.com/51792731/153065611-fb56932d-f7a1-472f-827c-65b91bea4cad.png">
