### PR TITLE
Add `protoSrcsDir` config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
               "default": "protoc",
               "description": "Path to protoc command"
             },
+            "protosSubdir": {
+              "type": "string",
+              "default": "**",
+              "description": "Path to subdirectory containing the protos"
+            },
             "options": {
               "type": "array",
               "items": {

--- a/package.json
+++ b/package.json
@@ -84,11 +84,6 @@
               "default": "protoc",
               "description": "Path to protoc command"
             },
-            "protosSubdir": {
-              "type": "string",
-              "default": "**",
-              "description": "Path to subdirectory containing the protos"
-            },
             "options": {
               "type": "array",
               "items": {

--- a/src/proto3Configuration.ts
+++ b/src/proto3Configuration.ts
@@ -34,6 +34,11 @@ export class Proto3Configuration {
             this._config.get<string>('compile_all_path', activeWorkspaceFolder.uri.path));
     }
 
+    public getProtoSrcsDir(): string {
+        return this._configResolver.resolve(
+            this._config.get<string>('protoSrcsDir', ''));
+    }
+
     public getProtocArgs(): string[] {
         return this._configResolver.resolve(
             this._config.get<string[]>('options', []));
@@ -77,7 +82,7 @@ class ProtoFinder {
             let files = fs.readdirSync(dir);
 
             let protos = files.filter(file => file.endsWith('.proto'))
-                          .map(file => path.join(path.relative(root, dir), file));
+                .map(file => path.join(path.relative(root, dir), file));
 
             files.map(file => path.join(dir, file))
                 .filter(file => fs.statSync(file).isDirectory())
@@ -115,12 +120,12 @@ class ConfigurationResolver {
 
     constructor(private readonly workspaceFolder?: vscode.WorkspaceFolder) {
         Object.keys(process.env).forEach(key => {
-			this[`env.${key}`] = process.env[key];
-		});
+            this[`env.${key}`] = process.env[key];
+        });
     }
 
-	public resolve(value: string): string;
-	public resolve(value: string[]): string[];
+    public resolve(value: string): string;
+    public resolve(value: string[]): string[];
     public resolve(value: any): any {
         if (typeof value === 'string') {
             return this.resolveString(value);
@@ -143,55 +148,55 @@ class ConfigurationResolver {
     }
 
     private resolveArray(value: string[]): string[] {
-		return value.map(s => this.resolveString(s));
-	}
+        return value.map(s => this.resolveString(s));
+    }
 
     private resolveString(value: string): string {
-		let regexp = /\$\{(.*?)\}/g;
-		const originalValue = value;
-		const resolvedString = value.replace(regexp, (match: string, name: string) => {
-			let newValue = (<any>this)[name];
-			if (typeof newValue === 'string') {
-				return newValue;
-			} else {
-				return match && match.indexOf('env.') > 0 ? '' : match;
-			}
-		});
+        let regexp = /\$\{(.*?)\}/g;
+        const originalValue = value;
+        const resolvedString = value.replace(regexp, (match: string, name: string) => {
+            let newValue = (<any>this)[name];
+            if (typeof newValue === 'string') {
+                return newValue;
+            } else {
+                return match && match.indexOf('env.') > 0 ? '' : match;
+            }
+        });
 
-		return this.resolveConfigVariable(resolvedString, originalValue);
-	}
+        return this.resolveConfigVariable(resolvedString, originalValue);
+    }
 
     private resolveConfigVariable(value: string, originalValue: string): string {
-		let regexp = /\$\{config\.(.+?)\}/g;
-		return value.replace(regexp, (match: string, name: string) => {
-			let config = vscode.workspace.getConfiguration(undefined, this.workspaceFolder);
-			let newValue: any;
-			try {
-				const keys: string[] = name.split('.');
-				if (!keys || keys.length <= 0) {
-					return '';
-				}
-				while (keys.length > 1) {
-					const key = keys.shift();
-					if (!config || !config.hasOwnProperty(key)) {
-						return '';
-					}
-					config = config[key];
-				}
-				newValue = config && config.hasOwnProperty(keys[0]) ? config[keys[0]] : '';
-			} catch (e) {
-				return '';
-			}
-			if (typeof newValue === 'string') {
-				// Prevent infinite recursion and also support nested references (or tokens)
-				return newValue === originalValue ? '' : this.resolveString(newValue);
-			} else {
-				return this.resolve(newValue) + '';
-			}
-		});
-	}
+        let regexp = /\$\{config\.(.+?)\}/g;
+        return value.replace(regexp, (match: string, name: string) => {
+            let config = vscode.workspace.getConfiguration(undefined, this.workspaceFolder);
+            let newValue: any;
+            try {
+                const keys: string[] = name.split('.');
+                if (!keys || keys.length <= 0) {
+                    return '';
+                }
+                while (keys.length > 1) {
+                    const key = keys.shift();
+                    if (!config || !config.hasOwnProperty(key)) {
+                        return '';
+                    }
+                    config = config[key];
+                }
+                newValue = config && config.hasOwnProperty(keys[0]) ? config[keys[0]] : '';
+            } catch (e) {
+                return '';
+            }
+            if (typeof newValue === 'string') {
+                // Prevent infinite recursion and also support nested references (or tokens)
+                return newValue === originalValue ? '' : this.resolveString(newValue);
+            } else {
+                return this.resolve(newValue) + '';
+            }
+        });
+    }
 
     private get workspaceRoot(): string {
-		return vscode.workspace.rootPath;
+        return vscode.workspace.rootPath;
     }
 }

--- a/src/proto3Configuration.ts
+++ b/src/proto3Configuration.ts
@@ -82,7 +82,7 @@ class ProtoFinder {
             let files = fs.readdirSync(dir);
 
             let protos = files.filter(file => file.endsWith('.proto'))
-                .map(file => path.join(path.relative(root, dir), file));
+                          .map(file => path.join(path.relative(root, dir), file));
 
             files.map(file => path.join(dir, file))
                 .filter(file => fs.statSync(file).isDirectory())
@@ -120,12 +120,12 @@ class ConfigurationResolver {
 
     constructor(private readonly workspaceFolder?: vscode.WorkspaceFolder) {
         Object.keys(process.env).forEach(key => {
-            this[`env.${key}`] = process.env[key];
-        });
+			this[`env.${key}`] = process.env[key];
+		});
     }
 
-    public resolve(value: string): string;
-    public resolve(value: string[]): string[];
+	public resolve(value: string): string;
+	public resolve(value: string[]): string[];
     public resolve(value: any): any {
         if (typeof value === 'string') {
             return this.resolveString(value);
@@ -148,55 +148,55 @@ class ConfigurationResolver {
     }
 
     private resolveArray(value: string[]): string[] {
-        return value.map(s => this.resolveString(s));
-    }
+		return value.map(s => this.resolveString(s));
+	}
 
     private resolveString(value: string): string {
-        let regexp = /\$\{(.*?)\}/g;
-        const originalValue = value;
-        const resolvedString = value.replace(regexp, (match: string, name: string) => {
-            let newValue = (<any>this)[name];
-            if (typeof newValue === 'string') {
-                return newValue;
-            } else {
-                return match && match.indexOf('env.') > 0 ? '' : match;
-            }
-        });
+		let regexp = /\$\{(.*?)\}/g;
+		const originalValue = value;
+		const resolvedString = value.replace(regexp, (match: string, name: string) => {
+			let newValue = (<any>this)[name];
+			if (typeof newValue === 'string') {
+				return newValue;
+			} else {
+				return match && match.indexOf('env.') > 0 ? '' : match;
+			}
+		});
 
-        return this.resolveConfigVariable(resolvedString, originalValue);
-    }
+		return this.resolveConfigVariable(resolvedString, originalValue);
+	}
 
     private resolveConfigVariable(value: string, originalValue: string): string {
-        let regexp = /\$\{config\.(.+?)\}/g;
-        return value.replace(regexp, (match: string, name: string) => {
-            let config = vscode.workspace.getConfiguration(undefined, this.workspaceFolder);
-            let newValue: any;
-            try {
-                const keys: string[] = name.split('.');
-                if (!keys || keys.length <= 0) {
-                    return '';
-                }
-                while (keys.length > 1) {
-                    const key = keys.shift();
-                    if (!config || !config.hasOwnProperty(key)) {
-                        return '';
-                    }
-                    config = config[key];
-                }
-                newValue = config && config.hasOwnProperty(keys[0]) ? config[keys[0]] : '';
-            } catch (e) {
-                return '';
-            }
-            if (typeof newValue === 'string') {
-                // Prevent infinite recursion and also support nested references (or tokens)
-                return newValue === originalValue ? '' : this.resolveString(newValue);
-            } else {
-                return this.resolve(newValue) + '';
-            }
-        });
-    }
+		let regexp = /\$\{config\.(.+?)\}/g;
+		return value.replace(regexp, (match: string, name: string) => {
+			let config = vscode.workspace.getConfiguration(undefined, this.workspaceFolder);
+			let newValue: any;
+			try {
+				const keys: string[] = name.split('.');
+				if (!keys || keys.length <= 0) {
+					return '';
+				}
+				while (keys.length > 1) {
+					const key = keys.shift();
+					if (!config || !config.hasOwnProperty(key)) {
+						return '';
+					}
+					config = config[key];
+				}
+				newValue = config && config.hasOwnProperty(keys[0]) ? config[keys[0]] : '';
+			} catch (e) {
+				return '';
+			}
+			if (typeof newValue === 'string') {
+				// Prevent infinite recursion and also support nested references (or tokens)
+				return newValue === originalValue ? '' : this.resolveString(newValue);
+			} else {
+				return this.resolve(newValue) + '';
+			}
+		});
+	}
 
     private get workspaceRoot(): string {
-        return vscode.workspace.rootPath;
+		return vscode.workspace.rootPath;
     }
 }

--- a/src/proto3Definition.ts
+++ b/src/proto3Definition.ts
@@ -7,9 +7,15 @@ import fg = require('fast-glob');
 import { guessScope, Proto3ScopeKind } from './proto3ScopeGuesser';
 import { Proto3Import } from './proto3Import';
 import { Proto3Primitive } from './proto3Primitive';
+import { Proto3Configuration } from './proto3Configuration';
 
 
 export class Proto3DefinitionProvider implements vscode.DefinitionProvider {
+    private _config: Proto3Configuration;
+
+    constructor(workspaceFolder?: vscode.WorkspaceFolder) {
+        this._config = Proto3Configuration.Instance(workspaceFolder);
+    }
 
     public async provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Definition> {
 
@@ -58,7 +64,7 @@ export class Proto3DefinitionProvider implements vscode.DefinitionProvider {
 
     private async findEnumOrMessageDefinition(document: vscode.TextDocument, target: string): Promise<vscode.Location> {
 
-        const searchPaths = Proto3Import.getImportedFilePathsOnDocument(document);
+        const searchPaths = Proto3Import.getImportedFilePathsOnDocument(document, this._config.getProtoSrcsDir());
 
         const files = [
             document.uri.fsPath,
@@ -81,7 +87,7 @@ export class Proto3DefinitionProvider implements vscode.DefinitionProvider {
     }
 
     private async findImportDefinition(importFileName: string): Promise<vscode.Location> {
-        const files = await fg(path.join(vscode.workspace.rootPath, 'common', 'proto', '**', importFileName));
+        const files = await fg(path.join(vscode.workspace.rootPath, this._config.getProtoSrcsDir(), '**', importFileName));
         const importPath = files[0].toString();
         // const data = fs.readFileSync(importPath);
         // const lines = data.toString().split('\n');

--- a/src/proto3Definition.ts
+++ b/src/proto3Definition.ts
@@ -81,7 +81,7 @@ export class Proto3DefinitionProvider implements vscode.DefinitionProvider {
     }
 
     private async findImportDefinition(importFileName: string): Promise<vscode.Location> {
-        const files = await fg(path.join(vscode.workspace.rootPath, vscode.WorkspaceConfiguration.get<string>('protosSubdir', '**'), importFileName));
+        const files = await fg(path.join(vscode.workspace.rootPath, 'common', 'proto', '**', importFileName));
         const importPath = files[0].toString();
         // const data = fs.readFileSync(importPath);
         // const lines = data.toString().split('\n');

--- a/src/proto3Definition.ts
+++ b/src/proto3Definition.ts
@@ -81,7 +81,7 @@ export class Proto3DefinitionProvider implements vscode.DefinitionProvider {
     }
 
     private async findImportDefinition(importFileName: string): Promise<vscode.Location> {
-        const files = await fg(path.join(vscode.workspace.rootPath, '**', importFileName));
+        const files = await fg(path.join(vscode.workspace.rootPath, vscode.WorkspaceConfiguration.get<string>('protosSubdir', '**'), importFileName));
         const importPath = files[0].toString();
         // const data = fs.readFileSync(importPath);
         // const lines = data.toString().split('\n');

--- a/src/proto3Import.ts
+++ b/src/proto3Import.ts
@@ -13,7 +13,7 @@ export module Proto3Import {
         let importPaths = [];
         while (importStatement = importStatementRegex.exec(fullDocument)) {
             const protoFileName = importStatement[2];
-            const searchPath = path.join(vscode.workspace.rootPath, vscode.WorkspaceConfiguration.get<string>('protosSubdir', '**'), protoFileName);
+            const searchPath = path.join(vscode.workspace.rootPath, 'common', 'proto', '**', protoFileName);
             importPaths.push(searchPath);
         }
         return importPaths;

--- a/src/proto3Import.ts
+++ b/src/proto3Import.ts
@@ -7,13 +7,13 @@ export module Proto3Import {
 
     export const importStatementRegex = new RegExp(/^\s*import\s+('|")(.+\.proto)('|")\s*;\s*$/gim);
 
-    export const getImportedFilePathsOnDocument = (document: vscode.TextDocument) => {
+    export const getImportedFilePathsOnDocument = (document: vscode.TextDocument, protoSrcsDir: string) => {
         const fullDocument = document.getText();
         let importStatement: RegExpExecArray;
         let importPaths = [];
         while (importStatement = importStatementRegex.exec(fullDocument)) {
             const protoFileName = importStatement[2];
-            const searchPath = path.join(vscode.workspace.rootPath, 'common', 'proto', '**', protoFileName);
+            const searchPath = path.join(vscode.workspace.rootPath, protoSrcsDir, '**', protoFileName);
             importPaths.push(searchPath);
         }
         return importPaths;

--- a/src/proto3Import.ts
+++ b/src/proto3Import.ts
@@ -13,7 +13,7 @@ export module Proto3Import {
         let importPaths = [];
         while (importStatement = importStatementRegex.exec(fullDocument)) {
             const protoFileName = importStatement[2];
-            const searchPath = path.join(vscode.workspace.rootPath, '**', protoFileName);
+            const searchPath = path.join(vscode.workspace.rootPath, vscode.WorkspaceConfiguration.get<string>('protosSubdir', '**'), protoFileName);
             importPaths.push(searchPath);
         }
         return importPaths;

--- a/src/proto3Main.ts
+++ b/src/proto3Main.ts
@@ -14,8 +14,9 @@ import { Proto3DocumentSymbolProvider } from './proto3SymbolProvider';
 
 export function activate(ctx: vscode.ExtensionContext): void {
 
+    const workspaceFolder = vscode.workspace.workspaceFolders[0];
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(PROTO3_MODE, new Proto3CompletionItemProvider(), '.', '\"'));
-    ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(PROTO3_MODE, new Proto3DefinitionProvider()));
+    ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(PROTO3_MODE, new Proto3DefinitionProvider(workspaceFolder)));
 
     const diagnosticProvider = new Proto3LanguageDiagnosticProvider();
 


### PR DESCRIPTION
Add a new config option, `protoSrcsDir`, which optionally limits the scope of proto file searches from `{workspaceRoot}/**` down to `{workspaceRoot}/path/to/protos/**`. This fixes an issue where autocompletion and go-to-definition calls are unuseably slow (upwards of 30 seconds) in repos with large numbers of ignored files (e.g. `node_modules`, `bazel-out`). With this fix, they are instant.

The "proper" way to fix this would be to respect VSCode's existing ignore lists in `settings.json`, but I'm not sure how to do that with fastglob in a way that actually improves performance. So, this solves the issue for now :)