### PR TITLE
Show enums within the document outline

### DIFF
--- a/src/proto3SymbolProvider.ts
+++ b/src/proto3SymbolProvider.ts
@@ -31,19 +31,14 @@ export class Proto3DocumentSymbolProvider implements DocumentSymbolProvider {
 
     // create cache entry
     const tokenizer = tokenize(doc.getText(), false);
-    let state: "free" | "rpc" | "message" | 'service' = "free"
+    let state: "free" | "rpc" | "message" | "service" | "enum" = "free"
     for (let tok = tokenizer.next(); tok !== null; tok = tokenizer.next()) {
       switch (tok) {
         case "message":
-          state = "message";
-          break;
-
         case "rpc":
-          state = "rpc";
-          break;
-
-        case 'service':
-          state = 'service';
+        case "service":
+        case "enum":
+          state = tok;
           break;
 
         default:
@@ -68,6 +63,9 @@ export class Proto3DocumentSymbolProvider implements DocumentSymbolProvider {
               break
             case 'service':
               kind = SymbolKind.Class;
+              break;
+            case 'enum':
+              kind = SymbolKind.Enum;
               break;
           }
           ret.push(new SymbolInformation(tok, kind, "", location));


### PR DESCRIPTION
I believe this was a minor oversight. Enums will now appear in the outline view alongside structs, services, and RPCs.

![image](https://github.com/zxh0/vscode-proto3/assets/7294642/c01f8777-2152-42b0-ab32-cbd4b6c0244e)
