### PR TITLE
fix: Update proto3.tmLanguage.json to fix some syntax highlighting bugs

### DIFF
--- a/syntaxes/proto3.tmLanguage.json
+++ b/syntaxes/proto3.tmLanguage.json
@@ -56,10 +56,10 @@
       }
     },
     "optionStmt": {
-      "begin": "(option)\\s+(\\w+|\\(\\w+(\\.\\w+)*\\))(\\.\\w+)*\\s*(=)",
+      "begin": "(option)\\s+(\\w+|\\((\\.\\w+)*\\))(\\.\\w+)*\\s*(=)",
       "beginCaptures": {
         "1": {"name": "keyword.other.proto"},
-        "2": {"name": "support.other.proto"},
+        "2": {"name": "keyword.other.proto"},
         "3": {"name": "support.other.proto"},
         "4": {"name": "support.other.proto"},
         "5": {"name": "keyword.operator.assignment.proto"}


### PR DESCRIPTION
This commit fixes the following issues:

1. The second method in service is not highlighted.
2. `option (.something.something)` is not highlighted.

| Before | After |
| ----- | ------ |
|<img width="500" alt="image" src="https://github.com/zxh0/vscode-proto3/assets/665703/9b0977c8-5c56-480f-90f3-d279d1d2b3d9"> | <img width="500" alt="image" src="https://github.com/zxh0/vscode-proto3/assets/665703/bb15e1b2-3040-4e25-92b2-f5d668ef3ad3"> |

Fixes #110