### PR TITLE
Fixes syntax highlighting for multiple strings in 1 line

### DIFF
--- a/syntaxes/proto3.tmLanguage.json
+++ b/syntaxes/proto3.tmLanguage.json
@@ -283,7 +283,7 @@
       "name": "storage.type.proto"
     },
     "string": {
-      "match": "('([^']|\\')*')|(\"([^\"]|\\\")*\")",
+      "match": "([\"'])(?:\\\\.|[^\\\\])*?\\1",
       "name": "string.quoted.double.proto"
     },
     "number": {


### PR DESCRIPTION
before
![Снимок экрана 2025-03-02 в 16 30 34](https://github.com/user-attachments/assets/2b09307b-f226-4056-9340-b8884e502e02)

after
![Снимок экрана 2025-03-02 в 16 30 50](https://github.com/user-attachments/assets/6b2ae75b-aaa2-4dce-9c6b-54da10ec1998)
