### PR TITLE
Fix renumbering bugs

### DIFF
--- a/src/proto3RenumberLogic.ts
+++ b/src/proto3RenumberLogic.ts
@@ -13,9 +13,86 @@ export interface NumericEdit {
   replacement: string;
 }
 
+/**
+ * Finds the innermost message or enum containing the given cursor offset.
+ *
+ * Example:
+ *   findEnclosingBlock('message Foo { string name = 1; }', 22);
+ *   // => { type: 'message', ... }
+ */
 export function findEnclosingBlock(text: string, offset: number): ProtoBlock | undefined {
-  const message = locateBlock(text, offset, 'message');
-  const enumeration = locateBlock(text, offset, 'enum');
+  return findEnclosingBlockInMaskedText(maskCommentsAndStrings(text), offset);
+}
+
+/**
+ * Returns every message and enum block in the document in source order.
+ *
+ * Example:
+ *   findAllBlocks('message Foo {} enum Bar {}').map(block => block.type);
+ *   // => ['message', 'enum']
+ */
+export function findAllBlocks(text: string): ProtoBlock[] {
+  return findAllBlocksInMaskedText(maskCommentsAndStrings(text));
+}
+
+/**
+ * Renumbers every message field and enum value in the document and returns the edits.
+ *
+ * Example:
+ *   computeDocumentRenumberEdits('message Foo { string name = 7; }');
+ *   // => edit that rewrites 7 -> 1
+ */
+export function computeDocumentRenumberEdits(text: string): NumericEdit[] {
+  const maskedText = maskCommentsAndStrings(text);
+  const edits: NumericEdit[] = [];
+
+  findAllBlocksInMaskedText(maskedText).forEach(block => {
+    const blockEdits =
+      block.type === 'enum'
+        ? computeEnumEditsInMaskedText(maskedText, block)
+        : computeMessageEditsInMaskedText(maskedText, block);
+    edits.push(...blockEdits);
+  });
+
+  return edits.sort((a, b) => a.start - b.start);
+}
+
+/**
+ * Renumbers the fields inside one message block, skipping nested messages and enums.
+ *
+ * Example:
+ *   computeMessageEdits('message Foo { string a = 9; int32 b = 12; }', block);
+ *   // => edits that rewrite 9 -> 1 and 12 -> 2
+ */
+export function computeMessageEdits(text: string, block: ProtoBlock): NumericEdit[] {
+  return computeMessageEditsInMaskedText(maskCommentsAndStrings(text), block);
+}
+
+/**
+ * Renumbers the values inside one enum block starting from zero.
+ *
+ * Example:
+ *   computeEnumEdits('enum State { UNKNOWN = 5; STARTED = 8; }', block);
+ *   // => edits that rewrite 5 -> 0 and 8 -> 1
+ */
+export function computeEnumEdits(text: string, block: ProtoBlock): NumericEdit[] {
+  return computeEnumEditsInMaskedText(maskCommentsAndStrings(text), block);
+}
+
+/**
+ * Reuses a pre-masked buffer to locate the innermost message or enum at an offset.
+ *
+ * Example:
+ *   const masked = maskCommentsAndStrings('message Foo { string name = 1; }');
+ *   findEnclosingBlockInMaskedText(masked, masked.indexOf('name'));
+ *   // => { type: 'message', ... }
+ */
+function findEnclosingBlockInMaskedText(
+  maskedText: string,
+  offset: number
+): ProtoBlock | undefined {
+  const message = locateBlock(maskedText, offset, 'message');
+  const enumeration = locateBlock(maskedText, offset, 'enum');
 
   if (message && enumeration) {
     return message.keywordStart > enumeration.keywordStart ? message : enumeration;
@@ -23,17 +100,22 @@ export function findEnclosingBlock(text: string, offset: number): ProtoBlock | u
   return message ?? enumeration ?? undefined;
 }
 
-export function findAllBlocks(text: string): ProtoBlock[] {
+/**
+ * Scans a pre-masked proto buffer and returns every message/enum block in source order.
+ *
+ * Example:
+ *   const masked = maskCommentsAndStrings('message Foo {} enum Bar {}');
+ *   findAllBlocksInMaskedText(masked).map(block => block.type);
+ *   // => ['message', 'enum']
+ */
+function findAllBlocksInMaskedText(maskedText: string): ProtoBlock[] {
   const blocks: ProtoBlock[] = [];
   const pattern = /\b(message|enum)\s+[A-Za-z_][\w]*\s*{/g;
   let match: RegExpExecArray | null;
 
-  while ((match = pattern.exec(text)) !== null) {
+  while ((match = pattern.exec(maskedText)) !== null) {
     const openBrace = match.index + match[0].lastIndexOf('{');
-    if (openBrace === -1) {
-      continue;
-    }
-    const closeBrace = findMatchingBrace(text, openBrace);
+    const closeBrace = findMatchingBrace(maskedText, openBrace);
     if (closeBrace === -1) {
       continue;
     }
@@ -48,17 +130,15 @@ export function findAllBlocks(text: string): ProtoBlock[] {
   return blocks;
 }
 
-export function computeDocumentRenumberEdits(text: string): NumericEdit[] {
-  const edits: NumericEdit[] = [];
-  findAllBlocks(text).forEach(block => {
-    const blockEdits =
-      block.type === 'enum' ? computeEnumEdits(text, block) : computeMessageEdits(text, block);
-    edits.push(...blockEdits);
-  });
-  return edits.sort((a, b) => a.start - b.start);
-}
-
-export function computeMessageEdits(text: string, block: ProtoBlock): NumericEdit[] {
+/**
+ * Computes message field renumber edits from a pre-masked buffer.
+ *
+ * Example:
+ *   const masked = maskCommentsAndStrings('message Foo { string a = 9; int32 b = 12; }');
+ *   computeMessageEditsInMaskedText(masked, findAllBlocksInMaskedText(masked)[0]);
+ *   // => edits that rewrite 9 -> 1 and 12 -> 2
+ */
+function computeMessageEditsInMaskedText(maskedText: string, block: ProtoBlock): NumericEdit[] {
   if (block.type !== 'message') {
     return [];
   }
@@ -66,24 +146,24 @@ export function computeMessageEdits(text: string, block: ProtoBlock): NumericEdi
   const edits: NumericEdit[] = [];
   const bodyStart = block.openBrace + 1;
   const bodyEnd = block.closeBrace;
-  const body = text.slice(bodyStart, bodyEnd);
-  const nested = collectNestedTypeRanges(text, bodyStart, bodyEnd);
+  const body = maskedText.slice(bodyStart, bodyEnd);
+  const nested = collectNestedTypeRanges(maskedText, bodyStart, bodyEnd);
   const pattern =
-    /^\s*(?:(?:repeated|optional|required)\s+)?(?:map<[^>]+>|[.A-Za-z_][\w<>.]*)\s+[A-Za-z_][\w]*\s*=\s*(\d+)/gm;
+    /^(\s*(?:(?:repeated|optional|required)\s+)?(?:map<[^>]+>|[.A-Za-z_][\w<>.]*)\s+[A-Za-z_][\w]*\s*=\s*)(\d+)/gm;
   let nextId = 1;
   let match: RegExpExecArray | null;
 
   while ((match = pattern.exec(body)) !== null) {
-    const digitsRelative = match[0].indexOf(match[1]);
+    const digitsRelative = match[1].length;
     const digitsStart = bodyStart + match.index + digitsRelative;
-    const digitsEnd = digitsStart + match[1].length;
+    const digitsEnd = digitsStart + match[2].length;
 
     if (isInsideNestedRange(digitsStart, nested)) {
       continue;
     }
 
     const replacement = String(nextId);
-    if (replacement !== match[1]) {
+    if (replacement !== match[2]) {
       edits.push({ start: digitsStart, end: digitsEnd, replacement });
     }
     nextId++;
@@ -92,7 +172,15 @@ export function computeMessageEdits(text: string, block: ProtoBlock): NumericEdi
   return edits;
 }
 
-export function computeEnumEdits(text: string, block: ProtoBlock): NumericEdit[] {
+/**
+ * Computes enum value renumber edits from a pre-masked buffer.
+ *
+ * Example:
+ *   const masked = maskCommentsAndStrings('enum State { UNKNOWN = 5; STARTED = 8; }');
+ *   computeEnumEditsInMaskedText(masked, findAllBlocksInMaskedText(masked)[0]);
+ *   // => edits that rewrite 5 -> 0 and 8 -> 1
+ */
+function computeEnumEditsInMaskedText(maskedText: string, block: ProtoBlock): NumericEdit[] {
   if (block.type !== 'enum') {
     return [];
   }
@@ -100,18 +188,20 @@ export function computeEnumEdits(text: string, block: ProtoBlock): NumericEdit[]
   const edits: NumericEdit[] = [];
   const bodyStart = block.openBrace + 1;
   const bodyEnd = block.closeBrace;
-  const body = text.slice(bodyStart, bodyEnd);
-  const pattern = /^\s*[A-Za-z_][\w]*\s*=\s*(-?\d+)/gm;
+  const body = maskedText.slice(bodyStart, bodyEnd);
+  // Hexadecimal renumbering is unlikely because hex values usually serve a specific purpose,
+  // but if the user requests it, we should handle it properly instead of corrupting the literal.
+  const pattern = /^(\s*[A-Za-z_][\w]*\s*=\s*)(-?(?:0[xX][0-9A-Fa-f]+|\d+))/gm;
   let nextId = 0;
   let match: RegExpExecArray | null;
 
   while ((match = pattern.exec(body)) !== null) {
-    const digitsRelative = match[0].indexOf(match[1]);
+    const digitsRelative = match[1].length;
     const digitsStart = bodyStart + match.index + digitsRelative;
-    const digitsEnd = digitsStart + match[1].length;
+    const digitsEnd = digitsStart + match[2].length;
     const replacement = String(nextId);
 
-    if (replacement !== match[1]) {
+    if (replacement !== match[2]) {
       edits.push({ start: digitsStart, end: digitsEnd, replacement });
     }
     nextId++;
@@ -129,10 +219,7 @@ function locateBlock(text: string, offset: number, keyword: BlockType): ProtoBlo
     if (match.index > offset) {
       break;
     }
-    const openBrace = text.indexOf('{', match.index);
-    if (openBrace === -1) {
-      continue;
-    }
+    const openBrace = match.index + match[0].lastIndexOf('{');
     const closeBrace = findMatchingBrace(text, openBrace);
     if (closeBrace === -1) {
       continue;
@@ -194,4 +281,80 @@ function findMatchingBrace(text: string, openBraceIndex: number): number {
     }
   }
   return -1;
+}
+
+/**
+ * Produces a same-length shadow buffer with comment and string contents masked out.
+ * This lets the renumbering parser ignore braces and number-like text inside those
+ * regions while keeping all original offsets valid for later edits.
+ *
+ * Example:
+ *   message Foo { option note = "}"; // comment with }
+ * becomes:
+ *   message Foo {
+ */
+function maskCommentsAndStrings(text: string): string {
+  let result = '';
+  let i = 0;
+
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (ch === '/' && next === '/') {
+      result += '  ';
+      i += 2;
+      while (i < text.length && text[i] !== '\n') {
+        result += ' ';
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      result += '  ';
+      i += 2;
+      while (i < text.length) {
+        const blockCh = text[i];
+        const blockNext = text[i + 1];
+        if (blockCh === '*' && blockNext === '/') {
+          result += '  ';
+          i += 2;
+          break;
+        }
+        result += blockCh === '\n' ? '\n' : ' ';
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      result += ' ';
+      i++;
+      while (i < text.length) {
+        const strCh = text[i];
+        if (strCh === '\\') {
+          result += ' ';
+          i++;
+          if (i < text.length) {
+            result += text[i] === '\n' ? '\n' : ' ';
+            i++;
+          }
+          continue;
+        }
+        result += strCh === '\n' ? '\n' : ' ';
+        i++;
+        if (strCh === quote) {
+          break;
+        }
+      }
+      continue;
+    }
+
+    result += ch;
+    i++;
+  }
+
+  return result;
 }

--- a/test/proto3RenumberLogic.test.ts
+++ b/test/proto3RenumberLogic.test.ts
@@ -5,6 +5,7 @@ import {
   computeMessageEdits,
   findEnclosingBlock,
 } from '../src/proto3RenumberLogic';
+import { applyEdits } from './testUtils';
 
 suite('Proto3RenumberLogic', () => {
   test('renumbers message fields while skipping nested messages', () => {
@@ -16,13 +17,9 @@ suite('Proto3RenumberLogic', () => {
 
     const edits = computeMessageEdits(text, block);
     assert.strictEqual(edits.length, 3);
-    assert.deepStrictEqual(
-      edits.map(edit => text.slice(edit.start, edit.end)),
-      ['5', '8', '11']
-    );
-    assert.deepStrictEqual(
-      edits.map(edit => edit.replacement),
-      ['1', '2', '3']
+    assert.strictEqual(
+      applyEdits(text, edits),
+      `message Outer {\n  string keep = 1;\n  message Inner {\n    string nested = 1;\n  }\n  oneof choice {\n    int32 picked = 2;\n    string named = 3;\n  }\n}`
     );
   });
 
@@ -46,9 +43,9 @@ suite('Proto3RenumberLogic', () => {
 
     const edits = computeEnumEdits(text, block);
     assert.strictEqual(edits.length, 2);
-    assert.deepStrictEqual(
-      edits.map(edit => edit.replacement),
-      ['0', '1']
+    assert.strictEqual(
+      applyEdits(text, edits),
+      `enum Sample {\n  SAMPLE_UNKNOWN = 0;\n  SAMPLE_CREATED = 1;\n}`
     );
   });
 
@@ -56,13 +53,9 @@ suite('Proto3RenumberLogic', () => {
     const text = `message Foo {\n  string keep = 3;\n  enum State {\n    UNKNOWN = 2;\n    STARTED = 5;\n  }\n  message Inner {\n    int64 value = 4;\n  }\n}`;
     const edits = computeDocumentRenumberEdits(text);
     assert.strictEqual(edits.length, 4);
-    assert.deepStrictEqual(
-      edits.map(edit => text.slice(edit.start, edit.end)),
-      ['3', '2', '5', '4']
-    );
-    assert.deepStrictEqual(
-      edits.map(edit => edit.replacement),
-      ['1', '0', '1', '1']
+    assert.strictEqual(
+      applyEdits(text, edits),
+      `message Foo {\n  string keep = 1;\n  enum State {\n    UNKNOWN = 0;\n    STARTED = 1;\n  }\n  message Inner {\n    int64 value = 1;\n  }\n}`
     );
   });
 });

--- a/test/proto3RenumberLogicExtended.test.ts
+++ b/test/proto3RenumberLogicExtended.test.ts
@@ -6,6 +6,7 @@ import {
   findAllBlocks,
   findEnclosingBlock,
 } from '../src/proto3RenumberLogic';
+import { applyEdits } from './testUtils';
 
 suite('Proto3RenumberLogic - Extended Tests', () => {
   suite('findEnclosingBlock', () => {
@@ -132,7 +133,7 @@ suite('Proto3RenumberLogic - Extended Tests', () => {
       const block = findAllBlocks(text)[0];
       const result = computeMessageEdits(text, block);
       assert.strictEqual(result.length, 1);
-      assert.strictEqual(result[0].replacement, '1');
+      assert.strictEqual(applyEdits(text, result), `message Foo {\n  string name = 1;\n}`);
     });
 
     test('renumbers multiple fields sequentially', () => {
@@ -140,9 +141,9 @@ suite('Proto3RenumberLogic - Extended Tests', () => {
       const block = findAllBlocks(text)[0];
       const result = computeMessageEdits(text, block);
       assert.strictEqual(result.length, 3);
-      assert.deepStrictEqual(
-        result.map(e => e.replacement),
-        ['1', '2', '3']
+      assert.strictEqual(
+        applyEdits(text, result),
+        `message Foo {\n  string a = 1;\n  int32 b = 2;\n  bool c = 3;\n}`
       );
     });
 
@@ -212,6 +213,18 @@ suite('Proto3RenumberLogic - Extended Tests', () => {
       assert.strictEqual(result.length, 1);
       assert.strictEqual(result[0].replacement, '1');
     });
+
+    test('renumbers field numbers without changing field names that include digits', () => {
+      const text = `message Foo {\n  string field_5 = 5;\n  string field_8 = 8;\n}`;
+      const block = findAllBlocks(text)[0];
+      const result = computeMessageEdits(text, block);
+
+      assert.strictEqual(result.length, 2);
+      assert.strictEqual(
+        applyEdits(text, result),
+        `message Foo {\n  string field_5 = 1;\n  string field_8 = 2;\n}`
+      );
+    });
   });
 
   suite('computeEnumEdits', () => {
@@ -234,9 +247,9 @@ suite('Proto3RenumberLogic - Extended Tests', () => {
       const block = findAllBlocks(text)[0];
       const result = computeEnumEdits(text, block);
       assert.strictEqual(result.length, 2);
-      assert.deepStrictEqual(
-        result.map(e => e.replacement),
-        ['0', '1']
+      assert.strictEqual(
+        applyEdits(text, result),
+        `enum Status {\n  UNKNOWN = 0;\n  ACTIVE = 1;\n}`
       );
     });
 
@@ -244,11 +257,10 @@ suite('Proto3RenumberLogic - Extended Tests', () => {
       const text = `enum Status {\n  NEGATIVE = -1;\n  ZERO = 0;\n}`;
       const block = findAllBlocks(text)[0];
       const result = computeEnumEdits(text, block);
-      // Should renumber to 0, 1
       assert.strictEqual(result.length, 2);
-      assert.deepStrictEqual(
-        result.map(e => e.replacement),
-        ['0', '1']
+      assert.strictEqual(
+        applyEdits(text, result),
+        `enum Status {\n  NEGATIVE = 0;\n  ZERO = 1;\n}`
       );
     });
 
@@ -264,6 +276,30 @@ suite('Proto3RenumberLogic - Extended Tests', () => {
       const block = findAllBlocks(text)[0];
       const result = computeEnumEdits(text, block);
       assert.strictEqual(result.length, 2);
+    });
+
+    test('renumbers enum values without changing enum names that include digits', () => {
+      const text = `enum Method {\n  GERG88_1 = 4;\n  GERG88_2 = 5;\n  GERG88_3 = 6;\n}`;
+      const block = findAllBlocks(text)[0];
+      const result = computeEnumEdits(text, block);
+
+      assert.strictEqual(result.length, 3);
+      assert.strictEqual(
+        applyEdits(text, result),
+        `enum Method {\n  GERG88_1 = 0;\n  GERG88_2 = 1;\n  GERG88_3 = 2;\n}`
+      );
+    });
+
+    test('replaces full hexadecimal enum literals', () => {
+      const text = `enum Status {\n  NEGATIVE = -0x20;\n  POSITIVE = 0x10;\n}`;
+      const block = findAllBlocks(text)[0];
+      const result = computeEnumEdits(text, block);
+
+      assert.strictEqual(result.length, 2);
+      assert.strictEqual(
+        applyEdits(text, result),
+        `enum Status {\n  NEGATIVE = 0;\n  POSITIVE = 1;\n}`
+      );
     });
   });
 
@@ -282,9 +318,9 @@ suite('Proto3RenumberLogic - Extended Tests', () => {
       const text = `message Foo {\n  string a = 5;\n}\n\nmessage Bar {\n  int32 b = 10;\n}`;
       const result = computeDocumentRenumberEdits(text);
       assert.strictEqual(result.length, 2);
-      assert.deepStrictEqual(
-        result.map(e => e.replacement),
-        ['1', '1']
+      assert.strictEqual(
+        applyEdits(text, result),
+        `message Foo {\n  string a = 1;\n}\n\nmessage Bar {\n  int32 b = 1;\n}`
       );
     });
 
@@ -292,6 +328,10 @@ suite('Proto3RenumberLogic - Extended Tests', () => {
       const text = `message Foo {\n  string a = 5;\n}\n\nenum Status {\n  UNKNOWN = 5;\n}`;
       const result = computeDocumentRenumberEdits(text);
       assert.strictEqual(result.length, 2);
+      assert.strictEqual(
+        applyEdits(text, result),
+        `message Foo {\n  string a = 1;\n}\n\nenum Status {\n  UNKNOWN = 0;\n}`
+      );
     });
 
     test('returns edits sorted by position', () => {
@@ -362,6 +402,20 @@ message Outer {
       const block = findAllBlocks(text)[0];
       const result = computeMessageEdits(text, block);
       assert.strictEqual(result.length, 1);
+    });
+
+    test('ignores braces inside comments when finding and renumbering blocks', () => {
+      const text = `message Foo {\n  // comment with }\n  string name = 5;\n}`;
+      const block = findEnclosingBlock(text, text.indexOf('name'));
+      assert.ok(block);
+      assert.strictEqual(block.type, 'message');
+
+      const result = computeMessageEdits(text, block);
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(
+        applyEdits(text, result),
+        `message Foo {\n  // comment with }\n  string name = 1;\n}`
+      );
     });
 
     test('handles reserved ranges', () => {

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,0 +1,20 @@
+import { NumericEdit } from '../src/proto3RenumberLogic';
+
+/**
+ * Applies offset-based edits from right to left so earlier ranges stay valid.
+ *
+ * Example:
+ *   applyEdits('a = 5; b = 8;', [
+ *     { start: 4, end: 5, replacement: '1' },
+ *     { start: 11, end: 12, replacement: '2' },
+ *   ]);
+ *   // => 'a = 1; b = 2;'
+ */
+export function applyEdits(text: string, edits: ReadonlyArray<NumericEdit>): string {
+  return [...edits]
+    .sort((a, b) => b.start - a.start)
+    .reduce(
+      (updated, edit) => updated.slice(0, edit.start) + edit.replacement + updated.slice(edit.end),
+      text
+    );
+}


### PR DESCRIPTION
Fix three renumbering bugs:
- Avoid rewriting field or enum names that contain digits when renumbering values
- Replace full hexadecimal enum literals instead of corrupting partial matches
- Ignore braces inside comments and strings when locating renumbering blocks

Add regression tests for each case, which demonstrate the bugs being fixed.

Also, introduces a test helper `applyEdits` to make some of the tests clearer (it allows asserting on the actual before/after of the replacement, making the assertion more obvious)

Fixes https://github.com/zxh0/vscode-proto3/issues/190